### PR TITLE
Harden session cookies and session lifetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ For production, override the session secret:
 
 - `AGENDABLE_SESSION_SECRET='...'`
 
+Session cookie hardening settings:
+
+- `AGENDABLE_SESSION_COOKIE_NAME='agendable_session'`
+- `AGENDABLE_SESSION_COOKIE_SAME_SITE='lax'` (`strict` recommended for production if your auth flow allows it)
+- `AGENDABLE_SESSION_COOKIE_HTTPS_ONLY='true'` (set `true` in production behind HTTPS)
+- `AGENDABLE_SESSION_COOKIE_MAX_AGE_SECONDS='1209600'` (default 14 days)
+
 ### Logging
 
 Runtime logging is configured via Python's built-in `logging` with environment-driven settings:

--- a/src/agendable/app.py
+++ b/src/agendable/app.py
@@ -85,7 +85,9 @@ def create_app() -> FastAPI:
         SessionMiddleware,
         secret_key=settings.session_secret.get_secret_value(),
         session_cookie=settings.session_cookie_name,
-        same_site="lax",
+        same_site=settings.session_cookie_same_site,
+        https_only=settings.session_cookie_https_only,
+        max_age=settings.session_cookie_max_age_seconds,
     )
 
     app.include_router(web_router)

--- a/src/agendable/settings.py
+++ b/src/agendable/settings.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from pydantic import SecretStr
+from typing import Literal
+
+from pydantic import Field, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -25,6 +27,9 @@ class Settings(BaseSettings):
     # Session cookie auth (MVP). In production, override via env.
     session_secret: SecretStr = SecretStr("dev-insecure-change-me")
     session_cookie_name: str = "agendable_session"
+    session_cookie_same_site: Literal["lax", "strict", "none"] = "lax"
+    session_cookie_https_only: bool = False
+    session_cookie_max_age_seconds: int = Field(default=60 * 60 * 24 * 14, ge=60)
 
     # Reminder integrations (optional for now)
     slack_webhook_url: SecretStr | None = None

--- a/tests/test_session_security.py
+++ b/tests/test_session_security.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pytest
+
+from agendable.app import create_app
+
+
+def _session_middleware_kwargs() -> dict[str, object]:
+    app = create_app()
+    middleware = next(
+        layer
+        for layer in app.user_middleware
+        if getattr(layer.cls, "__name__", "") == "SessionMiddleware"
+    )
+    return middleware.kwargs
+
+
+def test_session_cookie_hardening_settings_are_applied(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENDABLE_SESSION_COOKIE_SAME_SITE", "strict")
+    monkeypatch.setenv("AGENDABLE_SESSION_COOKIE_HTTPS_ONLY", "true")
+    monkeypatch.setenv("AGENDABLE_SESSION_COOKIE_MAX_AGE_SECONDS", "3600")
+    monkeypatch.setenv("AGENDABLE_SESSION_COOKIE_NAME", "agendable_test_session")
+
+    kwargs = _session_middleware_kwargs()
+
+    assert kwargs["session_cookie"] == "agendable_test_session"
+    assert kwargs["same_site"] == "strict"
+    assert kwargs["https_only"] is True
+    assert kwargs["max_age"] == 3600
+
+
+def test_session_cookie_defaults_are_set_for_local_dev(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AGENDABLE_SESSION_COOKIE_SAME_SITE", raising=False)
+    monkeypatch.delenv("AGENDABLE_SESSION_COOKIE_HTTPS_ONLY", raising=False)
+    monkeypatch.delenv("AGENDABLE_SESSION_COOKIE_MAX_AGE_SECONDS", raising=False)
+    monkeypatch.delenv("AGENDABLE_SESSION_COOKIE_NAME", raising=False)
+
+    kwargs = _session_middleware_kwargs()
+
+    assert kwargs["session_cookie"] == "agendable_session"
+    assert kwargs["same_site"] == "lax"
+    assert kwargs["https_only"] is False
+    assert kwargs["max_age"] == 60 * 60 * 24 * 14


### PR DESCRIPTION
Closes #12

## Summary
This PR hardens session cookie behavior by making cookie security flags and session lifetime explicitly configurable and applying them in middleware.

### Changes
- Added new settings:
  - `AGENDABLE_SESSION_COOKIE_SAME_SITE`
  - `AGENDABLE_SESSION_COOKIE_HTTPS_ONLY`
  - `AGENDABLE_SESSION_COOKIE_MAX_AGE_SECONDS`
- Wired these settings into `SessionMiddleware` config.
- Added tests to validate:
  - hardened cookie configuration is applied
  - safe local-dev defaults remain intact
- Updated README docs with the new session env vars.

## Validation
- `uv run pytest -q` ✅ (`103 passed`)

## Operational notes
For production:
- set `AGENDABLE_SESSION_COOKIE_HTTPS_ONLY=true`
- prefer `AGENDABLE_SESSION_COOKIE_SAME_SITE=strict` if your auth flow allows it
- set `AGENDABLE_SESSION_COOKIE_MAX_AGE_SECONDS` to your policy