### PR TITLE
Reminder delivery observability & bounded retry policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,13 @@ For local OIDC testing and multi-user flows, see the Keycloak setup in `README.m
 - Prefer HTMX-first UI updates and progressive enhancement over heavy frontend frameworks.
 - For schema changes, include an Alembic migration unless you explicitly document why not needed.
 
+### Layer boundaries
+- Entry points (`agendable.cli`, app startup wiring, route handlers) should stay orchestration-focused: parse inputs, call services, shape responses.
+- Service modules (`src/agendable/services/`) own business rules and workflow policy (for example retry/backoff decisions, state transitions, and cross-entity flow).
+- Repository modules (`src/agendable/db/repos/`) own persistence/query shaping and CRUD helpers; avoid embedding business policy in repositories.
+- Integration/adapters (for example `src/agendable/reminders.py`) own provider-specific behavior and error translation (SMTP/Slack/etc.).
+- If logic answers "what should happen," it belongs in a service. If it answers "how data is stored/fetched," it belongs in a repository.
+
 ## Before opening a PR
 Run the same checks CI enforces:
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Reminder scheduling defaults:
 - `AGENDABLE_REMINDER_WORKER_POLL_SECONDS` (default `60`)
 - `AGENDABLE_REMINDER_RETRY_MAX_ATTEMPTS` (default `3`)
 - `AGENDABLE_REMINDER_RETRY_BACKOFF_SECONDS` (default `60`, exponential backoff base)
+- `AGENDABLE_REMINDER_CLAIM_LEASE_SECONDS` (default `30`, temporary lease to prevent duplicate concurrent claims)
 
 Per-series override:
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Reminder scheduling defaults:
 - `AGENDABLE_ENABLE_DEFAULT_EMAIL_REMINDERS` (default `true`)
 - `AGENDABLE_DEFAULT_EMAIL_REMINDER_MINUTES_BEFORE` (default `60`)
 - `AGENDABLE_REMINDER_WORKER_POLL_SECONDS` (default `60`)
+- `AGENDABLE_REMINDER_RETRY_MAX_ATTEMPTS` (default `3`)
+- `AGENDABLE_REMINDER_RETRY_BACKOFF_SECONDS` (default `60`, exponential backoff base)
 
 Per-series override:
 

--- a/migrations/versions/0016_reminder_delivery_observability.py
+++ b/migrations/versions/0016_reminder_delivery_observability.py
@@ -1,0 +1,59 @@
+"""Add reminder delivery status, attempts, and failure reason tracking.
+
+Revision ID: 0016
+Revises: 0015
+Create Date: 2026-03-02
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0016"
+down_revision = "0015"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    delivery_status_enum = sa.Enum(
+        "pending",
+        "retry_scheduled",
+        "sent",
+        "failed_terminal",
+        "skipped",
+        name="reminder_delivery_status",
+    )
+    delivery_status_enum.create(op.get_bind(), checkfirst=True)
+
+    with op.batch_alter_table("reminder") as batch:
+        batch.add_column(sa.Column("next_attempt_at", sa.DateTime(timezone=True), nullable=True))
+        batch.add_column(sa.Column("last_attempted_at", sa.DateTime(timezone=True), nullable=True))
+        batch.add_column(
+            sa.Column("attempt_count", sa.Integer(), nullable=False, server_default="0")
+        )
+        batch.add_column(
+            sa.Column(
+                "delivery_status",
+                delivery_status_enum,
+                nullable=False,
+                server_default="pending",
+            )
+        )
+        batch.add_column(sa.Column("failure_reason_code", sa.String(length=64), nullable=True))
+
+    op.execute("UPDATE reminder SET next_attempt_at = send_at WHERE next_attempt_at IS NULL")
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("reminder") as batch:
+        batch.drop_column("failure_reason_code")
+        batch.drop_column("delivery_status")
+        batch.drop_column("attempt_count")
+        batch.drop_column("last_attempted_at")
+        batch.drop_column("next_attempt_at")
+
+    delivery_status_enum = sa.Enum(name="reminder_delivery_status")
+    delivery_status_enum.drop(op.get_bind(), checkfirst=True)

--- a/src/agendable/cli.py
+++ b/src/agendable/cli.py
@@ -22,12 +22,14 @@ async def _init_db() -> None:
 
 
 async def _claim_reminder_attempt(*, reminder: Reminder, now: datetime) -> bool:
+    settings = get_settings()
     async with db.SessionMaker() as claim_session:
         reminder_repo = ReminderRepository(claim_session)
         was_claimed = await reminder_repo.try_claim_attempt(
             reminder_id=reminder.id,
             expected_attempt_count=reminder.attempt_count,
             now=now,
+            claim_lease_seconds=settings.reminder_claim_lease_seconds,
         )
         if not was_claimed:
             return False

--- a/src/agendable/cli.py
+++ b/src/agendable/cli.py
@@ -3,41 +3,17 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
-from collections import Counter
-from dataclasses import dataclass, field
-from datetime import UTC, datetime, timedelta
-
-from sqlalchemy.ext.asyncio import AsyncSession
+from datetime import datetime
 
 import agendable.db as db
-from agendable.db.models import (
-    Base,
-    Reminder,
-    ReminderChannel,
-    ReminderDeliveryStatus,
-)
+from agendable.db.models import Base, Reminder
 from agendable.db.repos import ReminderRepository
-from agendable.logging_config import configure_logging, log_with_fields
-from agendable.reminders import (
-    ReminderDeliveryError,
-    ReminderEmail,
-    ReminderSender,
-    as_utc,
-    build_reminder_sender,
-)
+from agendable.logging_config import configure_logging
+from agendable.reminders import ReminderSender, build_reminder_sender
+from agendable.services.reminder_delivery_service import run_due_reminders
 from agendable.settings import get_settings
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass(slots=True)
-class ReminderRunStats:
-    attempted: int = 0
-    sent: int = 0
-    failed: int = 0
-    skipped: int = 0
-    retried: int = 0
-    failure_reason_counts: Counter[str] = field(default_factory=Counter)
 
 
 async def _init_db() -> None:
@@ -45,137 +21,32 @@ async def _init_db() -> None:
         await conn.run_sync(Base.metadata.create_all)
 
 
-def _is_reminder_due(reminder: Reminder, now: datetime) -> bool:
-    next_attempt_at = reminder.next_attempt_at if reminder.next_attempt_at else reminder.send_at
-    return as_utc(next_attempt_at) <= now
-
-
-async def _claim_reminder_attempt(
-    *,
-    session: AsyncSession,
-    reminder: Reminder,
-    now: datetime,
-) -> bool:
-    reminder_repo = ReminderRepository(session)
-    was_claimed = await reminder_repo.try_claim_attempt(
-        reminder_id=reminder.id,
-        expected_attempt_count=reminder.attempt_count,
-        now=now,
-    )
-    if not was_claimed:
-        return False
+async def _claim_reminder_attempt(*, reminder: Reminder, now: datetime) -> bool:
+    async with db.SessionMaker() as claim_session:
+        reminder_repo = ReminderRepository(claim_session)
+        was_claimed = await reminder_repo.try_claim_attempt(
+            reminder_id=reminder.id,
+            expected_attempt_count=reminder.attempt_count,
+            now=now,
+        )
+        if not was_claimed:
+            return False
+        await claim_session.commit()
 
     reminder.attempt_count += 1
     reminder.last_attempted_at = now
     return True
 
 
-def _build_reminder_email(reminder: Reminder) -> ReminderEmail:
-    return ReminderEmail(
-        recipient_email=reminder.occurrence.series.owner.email,
-        meeting_title=reminder.occurrence.series.title,
-        scheduled_at=as_utc(reminder.occurrence.scheduled_at),
-        incomplete_tasks=[task.title for task in reminder.occurrence.tasks if not task.is_done],
-    )
-
-
-def _log_run_summary(*, started_at: datetime, stats: ReminderRunStats) -> None:
-    duration_ms = int((datetime.now(UTC) - started_at).total_seconds() * 1000)
-    log_with_fields(
-        logger,
-        logging.INFO,
-        "reminder run complete",
-        attempted=stats.attempted,
-        sent=stats.sent,
-        failed=stats.failed,
-        skipped=stats.skipped,
-        retried=stats.retried,
-        duration_ms=duration_ms,
-    )
-
-    for reason_code, count in sorted(stats.failure_reason_counts.items()):
-        log_with_fields(
-            logger,
-            logging.INFO,
-            "reminder run failure reason",
-            reason_code=reason_code,
-            count=count,
-        )
-
-
 async def _run_due_reminders(sender: ReminderSender | None = None) -> None:
     settings = get_settings()
     selected_sender = sender if sender is not None else build_reminder_sender(settings)
-    started_at = datetime.now(UTC)
-    now = started_at
-    stats = ReminderRunStats()
-
-    async with db.SessionMaker() as session:
-        reminder_repo = ReminderRepository(session)
-        reminders = await reminder_repo.list_pending_for_delivery()
-        for reminder in reminders:
-            if not _is_reminder_due(reminder, now):
-                continue
-
-            if reminder.channel != ReminderChannel.email:
-                reminder.delivery_status = ReminderDeliveryStatus.skipped
-                reminder.failure_reason_code = "unsupported_channel"
-                stats.skipped += 1
-                continue
-
-            was_claimed = await _claim_reminder_attempt(session=session, reminder=reminder, now=now)
-            if not was_claimed:
-                continue
-
-            stats.attempted += 1
-
-            try:
-                await selected_sender.send_email_reminder(_build_reminder_email(reminder))
-            except ReminderDeliveryError as exc:
-                reminder.failure_reason_code = exc.reason_code
-                stats.failure_reason_counts[exc.reason_code] += 1
-                if (
-                    exc.is_transient
-                    and reminder.attempt_count < settings.reminder_retry_max_attempts
-                ):
-                    backoff_seconds = settings.reminder_retry_backoff_seconds * (
-                        2 ** (reminder.attempt_count - 1)
-                    )
-                    reminder.next_attempt_at = now + timedelta(seconds=backoff_seconds)
-                    reminder.delivery_status = ReminderDeliveryStatus.retry_scheduled
-                    stats.retried += 1
-                    log_with_fields(
-                        logger,
-                        logging.WARNING,
-                        "reminder delivery transient failure",
-                        reminder_id=reminder.id,
-                        reason_code=exc.reason_code,
-                        attempt_count=reminder.attempt_count,
-                        next_attempt_at=reminder.next_attempt_at.isoformat(),
-                        backoff_seconds=backoff_seconds,
-                    )
-                else:
-                    reminder.delivery_status = ReminderDeliveryStatus.failed_terminal
-                    stats.failed += 1
-                    log_with_fields(
-                        logger,
-                        logging.ERROR,
-                        "reminder delivery terminal failure",
-                        reminder_id=reminder.id,
-                        reason_code=exc.reason_code,
-                        attempt_count=reminder.attempt_count,
-                    )
-                continue
-
-            reminder.sent_at = now
-            reminder.next_attempt_at = now
-            reminder.delivery_status = ReminderDeliveryStatus.sent
-            reminder.failure_reason_code = None
-            stats.sent += 1
-
-        await session.commit()
-
-    _log_run_summary(started_at=started_at, stats=stats)
+    await run_due_reminders(
+        sender=selected_sender,
+        logger=logger,
+        settings=settings,
+        claim_attempt=_claim_reminder_attempt,
+    )
 
 
 async def _run_reminders_worker(poll_seconds: int) -> None:

--- a/src/agendable/cli.py
+++ b/src/agendable/cli.py
@@ -3,18 +3,46 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
-from datetime import UTC, datetime
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import cast
 
-from sqlalchemy import select
+from sqlalchemy import or_, select, update
+from sqlalchemy.engine import CursorResult
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 import agendable.db as db
-from agendable.db.models import Base, MeetingOccurrence, MeetingSeries, Reminder, ReminderChannel
+from agendable.db.models import (
+    Base,
+    MeetingOccurrence,
+    MeetingSeries,
+    Reminder,
+    ReminderChannel,
+    ReminderDeliveryStatus,
+)
 from agendable.logging_config import configure_logging, log_with_fields
-from agendable.reminders import ReminderEmail, ReminderSender, as_utc, build_reminder_sender
+from agendable.reminders import (
+    ReminderDeliveryError,
+    ReminderEmail,
+    ReminderSender,
+    as_utc,
+    build_reminder_sender,
+)
 from agendable.settings import get_settings
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class ReminderRunStats:
+    attempted: int = 0
+    sent: int = 0
+    failed: int = 0
+    skipped: int = 0
+    retried: int = 0
+    failure_reason_counts: Counter[str] = field(default_factory=Counter)
 
 
 async def _init_db() -> None:
@@ -22,9 +50,84 @@ async def _init_db() -> None:
         await conn.run_sync(Base.metadata.create_all)
 
 
+def _is_reminder_due(reminder: Reminder, now: datetime) -> bool:
+    next_attempt_at = reminder.next_attempt_at if reminder.next_attempt_at else reminder.send_at
+    return as_utc(next_attempt_at) <= now
+
+
+async def _claim_reminder_attempt(
+    *,
+    session: AsyncSession,
+    reminder: Reminder,
+    now: datetime,
+) -> bool:
+    claim_result = await session.execute(
+        update(Reminder)
+        .where(Reminder.id == reminder.id)
+        .where(Reminder.sent_at.is_(None))
+        .where(
+            Reminder.delivery_status.in_(
+                [ReminderDeliveryStatus.pending, ReminderDeliveryStatus.retry_scheduled]
+            )
+        )
+        .where(Reminder.attempt_count == reminder.attempt_count)
+        .where(or_(Reminder.next_attempt_at.is_(None), Reminder.next_attempt_at <= now))
+        .values(
+            attempt_count=Reminder.attempt_count + 1,
+            last_attempted_at=now,
+        )
+        .execution_options(synchronize_session=False)
+    )
+
+    claim_rowcount = cast(CursorResult[object], claim_result).rowcount
+    if claim_rowcount != 1:
+        return False
+
+    reminder.attempt_count += 1
+    reminder.last_attempted_at = now
+    return True
+
+
+def _build_reminder_email(reminder: Reminder) -> ReminderEmail:
+    return ReminderEmail(
+        recipient_email=reminder.occurrence.series.owner.email,
+        meeting_title=reminder.occurrence.series.title,
+        scheduled_at=as_utc(reminder.occurrence.scheduled_at),
+        incomplete_tasks=[task.title for task in reminder.occurrence.tasks if not task.is_done],
+    )
+
+
+def _log_run_summary(*, started_at: datetime, stats: ReminderRunStats) -> None:
+    duration_ms = int((datetime.now(UTC) - started_at).total_seconds() * 1000)
+    log_with_fields(
+        logger,
+        logging.INFO,
+        "reminder run complete",
+        attempted=stats.attempted,
+        sent=stats.sent,
+        failed=stats.failed,
+        skipped=stats.skipped,
+        retried=stats.retried,
+        duration_ms=duration_ms,
+    )
+
+    for reason_code, count in sorted(stats.failure_reason_counts.items()):
+        log_with_fields(
+            logger,
+            logging.INFO,
+            "reminder run failure reason",
+            reason_code=reason_code,
+            count=count,
+        )
+
+
 async def _run_due_reminders(sender: ReminderSender | None = None) -> None:
-    selected_sender = sender if sender is not None else build_reminder_sender(get_settings())
-    now = datetime.now(UTC)
+    settings = get_settings()
+    selected_sender = sender if sender is not None else build_reminder_sender(settings)
+    started_at = datetime.now(UTC)
+    now = started_at
+    stats = ReminderRunStats()
+
     async with db.SessionMaker() as session:
         result = await session.execute(
             select(Reminder)
@@ -35,36 +138,77 @@ async def _run_due_reminders(sender: ReminderSender | None = None) -> None:
                 selectinload(Reminder.occurrence).selectinload(MeetingOccurrence.tasks),
             )
             .where(Reminder.sent_at.is_(None))
-            .order_by(Reminder.send_at.asc())
+            .where(
+                Reminder.delivery_status.in_(
+                    [ReminderDeliveryStatus.pending, ReminderDeliveryStatus.retry_scheduled]
+                )
+            )
+            .order_by(Reminder.next_attempt_at.asc())
         )
         reminders = list(result.scalars().all())
-
-        sent = 0
-        skipped = 0
         for reminder in reminders:
-            if as_utc(reminder.send_at) > now:
+            if not _is_reminder_due(reminder, now):
                 continue
 
             if reminder.channel != ReminderChannel.email:
-                skipped += 1
+                reminder.delivery_status = ReminderDeliveryStatus.skipped
+                reminder.failure_reason_code = "unsupported_channel"
+                stats.skipped += 1
                 continue
 
-            await selected_sender.send_email_reminder(
-                ReminderEmail(
-                    recipient_email=reminder.occurrence.series.owner.email,
-                    meeting_title=reminder.occurrence.series.title,
-                    scheduled_at=as_utc(reminder.occurrence.scheduled_at),
-                    incomplete_tasks=[
-                        task.title for task in reminder.occurrence.tasks if not task.is_done
-                    ],
-                )
-            )
+            was_claimed = await _claim_reminder_attempt(session=session, reminder=reminder, now=now)
+            if not was_claimed:
+                continue
+
+            stats.attempted += 1
+
+            try:
+                await selected_sender.send_email_reminder(_build_reminder_email(reminder))
+            except ReminderDeliveryError as exc:
+                reminder.failure_reason_code = exc.reason_code
+                stats.failure_reason_counts[exc.reason_code] += 1
+                if (
+                    exc.is_transient
+                    and reminder.attempt_count < settings.reminder_retry_max_attempts
+                ):
+                    backoff_seconds = settings.reminder_retry_backoff_seconds * (
+                        2 ** (reminder.attempt_count - 1)
+                    )
+                    reminder.next_attempt_at = now + timedelta(seconds=backoff_seconds)
+                    reminder.delivery_status = ReminderDeliveryStatus.retry_scheduled
+                    stats.retried += 1
+                    log_with_fields(
+                        logger,
+                        logging.WARNING,
+                        "reminder delivery transient failure",
+                        reminder_id=reminder.id,
+                        reason_code=exc.reason_code,
+                        attempt_count=reminder.attempt_count,
+                        next_attempt_at=reminder.next_attempt_at.isoformat(),
+                        backoff_seconds=backoff_seconds,
+                    )
+                else:
+                    reminder.delivery_status = ReminderDeliveryStatus.failed_terminal
+                    stats.failed += 1
+                    log_with_fields(
+                        logger,
+                        logging.ERROR,
+                        "reminder delivery terminal failure",
+                        reminder_id=reminder.id,
+                        reason_code=exc.reason_code,
+                        attempt_count=reminder.attempt_count,
+                    )
+                continue
+
             reminder.sent_at = now
-            sent += 1
+            reminder.next_attempt_at = now
+            reminder.delivery_status = ReminderDeliveryStatus.sent
+            reminder.failure_reason_code = None
+            stats.sent += 1
 
         await session.commit()
 
-    log_with_fields(logger, logging.INFO, "reminder run complete", sent=sent, skipped=skipped)
+    _log_run_summary(started_at=started_at, stats=stats)
 
 
 async def _run_reminders_worker(poll_seconds: int) -> None:

--- a/src/agendable/cli.py
+++ b/src/agendable/cli.py
@@ -6,22 +6,17 @@ import logging
 from collections import Counter
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
-from typing import cast
 
-from sqlalchemy import or_, select, update
-from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 import agendable.db as db
 from agendable.db.models import (
     Base,
-    MeetingOccurrence,
-    MeetingSeries,
     Reminder,
     ReminderChannel,
     ReminderDeliveryStatus,
 )
+from agendable.db.repos import ReminderRepository
 from agendable.logging_config import configure_logging, log_with_fields
 from agendable.reminders import (
     ReminderDeliveryError,
@@ -61,26 +56,13 @@ async def _claim_reminder_attempt(
     reminder: Reminder,
     now: datetime,
 ) -> bool:
-    claim_result = await session.execute(
-        update(Reminder)
-        .where(Reminder.id == reminder.id)
-        .where(Reminder.sent_at.is_(None))
-        .where(
-            Reminder.delivery_status.in_(
-                [ReminderDeliveryStatus.pending, ReminderDeliveryStatus.retry_scheduled]
-            )
-        )
-        .where(Reminder.attempt_count == reminder.attempt_count)
-        .where(or_(Reminder.next_attempt_at.is_(None), Reminder.next_attempt_at <= now))
-        .values(
-            attempt_count=Reminder.attempt_count + 1,
-            last_attempted_at=now,
-        )
-        .execution_options(synchronize_session=False)
+    reminder_repo = ReminderRepository(session)
+    was_claimed = await reminder_repo.try_claim_attempt(
+        reminder_id=reminder.id,
+        expected_attempt_count=reminder.attempt_count,
+        now=now,
     )
-
-    claim_rowcount = cast(CursorResult[object], claim_result).rowcount
-    if claim_rowcount != 1:
+    if not was_claimed:
         return False
 
     reminder.attempt_count += 1
@@ -129,23 +111,8 @@ async def _run_due_reminders(sender: ReminderSender | None = None) -> None:
     stats = ReminderRunStats()
 
     async with db.SessionMaker() as session:
-        result = await session.execute(
-            select(Reminder)
-            .options(
-                selectinload(Reminder.occurrence)
-                .selectinload(MeetingOccurrence.series)
-                .selectinload(MeetingSeries.owner),
-                selectinload(Reminder.occurrence).selectinload(MeetingOccurrence.tasks),
-            )
-            .where(Reminder.sent_at.is_(None))
-            .where(
-                Reminder.delivery_status.in_(
-                    [ReminderDeliveryStatus.pending, ReminderDeliveryStatus.retry_scheduled]
-                )
-            )
-            .order_by(Reminder.next_attempt_at.asc())
-        )
-        reminders = list(result.scalars().all())
+        reminder_repo = ReminderRepository(session)
+        reminders = await reminder_repo.list_pending_for_delivery()
         for reminder in reminders:
             if not _is_reminder_due(reminder, now):
                 continue

--- a/src/agendable/db/models.py
+++ b/src/agendable/db/models.py
@@ -27,6 +27,14 @@ class ReminderChannel(enum.StrEnum):
     slack = "slack"
 
 
+class ReminderDeliveryStatus(enum.StrEnum):
+    pending = "pending"
+    retry_scheduled = "retry_scheduled"
+    sent = "sent"
+    failed_terminal = "failed_terminal"
+    skipped = "skipped"
+
+
 class UserRole(enum.StrEnum):
     user = "user"
     admin = "admin"
@@ -224,6 +232,16 @@ class Reminder(Base):
 
     channel: Mapped[ReminderChannel] = mapped_column(Enum(ReminderChannel, name="reminder_channel"))
     send_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), index=True)
+    next_attempt_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), index=True)
     sent_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_attempted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    attempt_count: Mapped[int] = mapped_column(Integer, default=0)
+    delivery_status: Mapped[ReminderDeliveryStatus] = mapped_column(
+        Enum(ReminderDeliveryStatus, name="reminder_delivery_status"),
+        default=ReminderDeliveryStatus.pending,
+    )
+    failure_reason_code: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
     occurrence: Mapped[MeetingOccurrence] = relationship(back_populates="reminders")

--- a/src/agendable/db/repos/__init__.py
+++ b/src/agendable/db/repos/__init__.py
@@ -6,16 +6,20 @@ Keep them focused on persistence/query shaping; business logic lives in services
 
 from agendable.db.repos.agenda_items import AgendaItemRepository
 from agendable.db.repos.external_identities import ExternalIdentityRepository
+from agendable.db.repos.meeting_occurrence_attendees import MeetingOccurrenceAttendeeRepository
 from agendable.db.repos.meeting_occurrences import MeetingOccurrenceRepository
 from agendable.db.repos.meeting_series import MeetingSeriesRepository
+from agendable.db.repos.reminders import ReminderRepository
 from agendable.db.repos.tasks import TaskRepository
 from agendable.db.repos.users import UserRepository
 
 __all__ = [
     "AgendaItemRepository",
     "ExternalIdentityRepository",
+    "MeetingOccurrenceAttendeeRepository",
     "MeetingOccurrenceRepository",
     "MeetingSeriesRepository",
+    "ReminderRepository",
     "TaskRepository",
     "UserRepository",
 ]

--- a/src/agendable/db/repos/meeting_occurrence_attendees.py
+++ b/src/agendable/db/repos/meeting_occurrence_attendees.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from agendable.db.models import MeetingOccurrenceAttendee
+from agendable.db.repos.base import BaseRepository
+
+
+class MeetingOccurrenceAttendeeRepository(BaseRepository[MeetingOccurrenceAttendee]):
+    def __init__(self, session: AsyncSession) -> None:
+        super().__init__(session, MeetingOccurrenceAttendee)
+
+    async def get_by_occurrence_and_user(
+        self,
+        occurrence_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> MeetingOccurrenceAttendee | None:
+        result = await self.session.execute(
+            select(MeetingOccurrenceAttendee).where(
+                MeetingOccurrenceAttendee.occurrence_id == occurrence_id,
+                MeetingOccurrenceAttendee.user_id == user_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def list_occurrence_ids_for_user(
+        self,
+        *,
+        user_id: uuid.UUID,
+        occurrence_ids: list[uuid.UUID],
+    ) -> set[uuid.UUID]:
+        if not occurrence_ids:
+            return set()
+
+        result = await self.session.execute(
+            select(MeetingOccurrenceAttendee.occurrence_id).where(
+                MeetingOccurrenceAttendee.user_id == user_id,
+                MeetingOccurrenceAttendee.occurrence_id.in_(occurrence_ids),
+            )
+        )
+        return set(result.scalars().all())
+
+    async def add_link(
+        self,
+        *,
+        occurrence_id: uuid.UUID,
+        user_id: uuid.UUID,
+        flush: bool = False,
+    ) -> MeetingOccurrenceAttendee:
+        link = MeetingOccurrenceAttendee(occurrence_id=occurrence_id, user_id=user_id)
+        self.session.add(link)
+        if flush:
+            await self.session.flush()
+        return link
+
+    async def add_missing_links(
+        self,
+        *,
+        user_id: uuid.UUID,
+        occurrence_ids: list[uuid.UUID],
+        existing_occurrence_ids: set[uuid.UUID],
+    ) -> int:
+        added_count = 0
+        for occurrence_id in occurrence_ids:
+            if occurrence_id in existing_occurrence_ids:
+                continue
+            await self.add_link(occurrence_id=occurrence_id, user_id=user_id, flush=False)
+            added_count += 1
+        return added_count

--- a/src/agendable/db/repos/reminders.py
+++ b/src/agendable/db/repos/reminders.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import cast
 
 from sqlalchemy import or_, select, update
@@ -47,6 +47,7 @@ class ReminderRepository(BaseRepository[Reminder]):
         reminder_id: uuid.UUID,
         expected_attempt_count: int,
         now: datetime,
+        claim_lease_seconds: int,
     ) -> bool:
         claim_result = await self.session.execute(
             update(Reminder)
@@ -62,6 +63,7 @@ class ReminderRepository(BaseRepository[Reminder]):
             .values(
                 attempt_count=Reminder.attempt_count + 1,
                 last_attempted_at=now,
+                next_attempt_at=now + timedelta(seconds=claim_lease_seconds),
             )
             .execution_options(synchronize_session=False)
         )

--- a/src/agendable/db/repos/reminders.py
+++ b/src/agendable/db/repos/reminders.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import cast
+
+from sqlalchemy import or_, select, update
+from sqlalchemy.engine import CursorResult
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from agendable.db.models import (
+    MeetingOccurrence,
+    MeetingSeries,
+    Reminder,
+    ReminderDeliveryStatus,
+)
+from agendable.db.repos.base import BaseRepository
+
+
+class ReminderRepository(BaseRepository[Reminder]):
+    def __init__(self, session: AsyncSession) -> None:
+        super().__init__(session, Reminder)
+
+    async def list_pending_for_delivery(self) -> list[Reminder]:
+        result = await self.session.execute(
+            select(Reminder)
+            .options(
+                selectinload(Reminder.occurrence)
+                .selectinload(MeetingOccurrence.series)
+                .selectinload(MeetingSeries.owner),
+                selectinload(Reminder.occurrence).selectinload(MeetingOccurrence.tasks),
+            )
+            .where(Reminder.sent_at.is_(None))
+            .where(
+                Reminder.delivery_status.in_(
+                    [ReminderDeliveryStatus.pending, ReminderDeliveryStatus.retry_scheduled]
+                )
+            )
+            .order_by(Reminder.next_attempt_at.asc())
+        )
+        return list(result.scalars().all())
+
+    async def try_claim_attempt(
+        self,
+        *,
+        reminder_id: uuid.UUID,
+        expected_attempt_count: int,
+        now: datetime,
+    ) -> bool:
+        claim_result = await self.session.execute(
+            update(Reminder)
+            .where(Reminder.id == reminder_id)
+            .where(Reminder.sent_at.is_(None))
+            .where(
+                Reminder.delivery_status.in_(
+                    [ReminderDeliveryStatus.pending, ReminderDeliveryStatus.retry_scheduled]
+                )
+            )
+            .where(Reminder.attempt_count == expected_attempt_count)
+            .where(or_(Reminder.next_attempt_at.is_(None), Reminder.next_attempt_at <= now))
+            .values(
+                attempt_count=Reminder.attempt_count + 1,
+                last_attempted_at=now,
+            )
+            .execution_options(synchronize_session=False)
+        )
+
+        claim_rowcount = cast(CursorResult[object], claim_result).rowcount
+        return claim_rowcount == 1

--- a/src/agendable/reminders.py
+++ b/src/agendable/reminders.py
@@ -24,6 +24,44 @@ class ReminderSender(Protocol):
     async def send_email_reminder(self, reminder: ReminderEmail) -> None: ...
 
 
+@dataclass(slots=True)
+class ReminderDeliveryError(Exception):
+    reason_code: str
+    is_transient: bool
+
+
+class TransientReminderDeliveryError(ReminderDeliveryError):
+    def __init__(self, reason_code: str) -> None:
+        super().__init__(reason_code=reason_code, is_transient=True)
+
+
+class TerminalReminderDeliveryError(ReminderDeliveryError):
+    def __init__(self, reason_code: str) -> None:
+        super().__init__(reason_code=reason_code, is_transient=False)
+
+
+def classify_smtp_error(exc: Exception) -> ReminderDeliveryError:
+    if isinstance(
+        exc,
+        (
+            smtplib.SMTPConnectError,
+            smtplib.SMTPServerDisconnected,
+            TimeoutError,
+        ),
+    ):
+        return TransientReminderDeliveryError("smtp_unavailable")
+
+    if isinstance(exc, smtplib.SMTPAuthenticationError):
+        return TerminalReminderDeliveryError("smtp_auth_failed")
+
+    if isinstance(exc, smtplib.SMTPResponseException):
+        if 400 <= exc.smtp_code < 500:
+            return TransientReminderDeliveryError("smtp_transient_response")
+        return TerminalReminderDeliveryError("smtp_permanent_response")
+
+    return TerminalReminderDeliveryError("smtp_unknown")
+
+
 def as_utc(dt: datetime) -> datetime:
     if dt.tzinfo is None:
         return dt.replace(tzinfo=UTC)
@@ -48,6 +86,7 @@ def build_default_email_reminder(
         occurrence_id=occurrence_id,
         channel=ReminderChannel.email,
         send_at=send_at,
+        next_attempt_at=send_at,
         sent_at=None,
     )
 
@@ -80,7 +119,10 @@ class SmtpReminderSender:
         self.timeout_seconds = timeout_seconds
 
     async def send_email_reminder(self, reminder: ReminderEmail) -> None:
-        await asyncio.to_thread(self._send_sync, reminder)
+        try:
+            await asyncio.to_thread(self._send_sync, reminder)
+        except Exception as exc:
+            raise classify_smtp_error(exc) from exc
 
     def _send_sync(self, reminder: ReminderEmail) -> None:
         message = EmailMessage()

--- a/src/agendable/services/__init__.py
+++ b/src/agendable/services/__init__.py
@@ -6,6 +6,7 @@ from agendable.services.oidc_service import (
     resolve_oidc_link_resolution,
     resolve_oidc_login_resolution,
 )
+from agendable.services.reminder_delivery_service import run_due_reminders
 from agendable.services.series_service import create_series_with_occurrences
 
 __all__ = [
@@ -16,4 +17,5 @@ __all__ = [
     "provision_user_for_oidc",
     "resolve_oidc_link_resolution",
     "resolve_oidc_login_resolution",
+    "run_due_reminders",
 ]

--- a/src/agendable/services/reminder_delivery_service.py
+++ b/src/agendable/services/reminder_delivery_service.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+import agendable.db as db
+from agendable.db.models import Reminder, ReminderChannel, ReminderDeliveryStatus
+from agendable.db.repos import ReminderRepository
+from agendable.logging_config import log_with_fields
+from agendable.reminders import ReminderDeliveryError, ReminderEmail, ReminderSender, as_utc
+from agendable.settings import Settings, get_settings
+
+
+@dataclass(slots=True)
+class ReminderRunStats:
+    attempted: int = 0
+    sent: int = 0
+    failed: int = 0
+    skipped: int = 0
+    retried: int = 0
+    failure_reason_counts: Counter[str] = field(default_factory=Counter)
+
+
+def _is_reminder_due(reminder: Reminder, now: datetime) -> bool:
+    next_attempt_at = reminder.next_attempt_at if reminder.next_attempt_at else reminder.send_at
+    return as_utc(next_attempt_at) <= now
+
+
+async def claim_reminder_attempt(*, reminder: Reminder, now: datetime) -> bool:
+    async with db.SessionMaker() as claim_session:
+        reminder_repo = ReminderRepository(claim_session)
+        was_claimed = await reminder_repo.try_claim_attempt(
+            reminder_id=reminder.id,
+            expected_attempt_count=reminder.attempt_count,
+            now=now,
+        )
+        if not was_claimed:
+            return False
+
+        await claim_session.commit()
+
+    reminder.attempt_count += 1
+    reminder.last_attempted_at = now
+    return True
+
+
+def _build_reminder_email(reminder: Reminder) -> ReminderEmail:
+    return ReminderEmail(
+        recipient_email=reminder.occurrence.series.owner.email,
+        meeting_title=reminder.occurrence.series.title,
+        scheduled_at=as_utc(reminder.occurrence.scheduled_at),
+        incomplete_tasks=[task.title for task in reminder.occurrence.tasks if not task.is_done],
+    )
+
+
+def _log_run_summary(
+    *, logger: logging.Logger, started_at: datetime, stats: ReminderRunStats
+) -> None:
+    duration_ms = int((datetime.now(UTC) - started_at).total_seconds() * 1000)
+    log_with_fields(
+        logger,
+        logging.INFO,
+        "reminder run complete",
+        attempted=stats.attempted,
+        sent=stats.sent,
+        failed=stats.failed,
+        skipped=stats.skipped,
+        retried=stats.retried,
+        duration_ms=duration_ms,
+    )
+
+    for reason_code, count in sorted(stats.failure_reason_counts.items()):
+        log_with_fields(
+            logger,
+            logging.INFO,
+            "reminder run failure reason",
+            reason_code=reason_code,
+            count=count,
+        )
+
+
+async def run_due_reminders(
+    *,
+    sender: ReminderSender,
+    logger: logging.Logger,
+    settings: Settings | None = None,
+    claim_attempt: Callable[..., Awaitable[bool]] | None = None,
+) -> None:
+    selected_settings = settings if settings is not None else get_settings()
+    started_at = datetime.now(UTC)
+    now = started_at
+    stats = ReminderRunStats()
+    selected_claim_attempt = claim_attempt if claim_attempt is not None else claim_reminder_attempt
+
+    async with db.SessionMaker() as session:
+        reminder_repo = ReminderRepository(session)
+        reminders = await reminder_repo.list_pending_for_delivery()
+        for reminder in reminders:
+            if not _is_reminder_due(reminder, now):
+                continue
+
+            if reminder.channel != ReminderChannel.email:
+                reminder.delivery_status = ReminderDeliveryStatus.skipped
+                reminder.failure_reason_code = "unsupported_channel"
+                stats.skipped += 1
+                continue
+
+            was_claimed = await selected_claim_attempt(reminder=reminder, now=now)
+            if not was_claimed:
+                continue
+
+            stats.attempted += 1
+
+            try:
+                await sender.send_email_reminder(_build_reminder_email(reminder))
+            except ReminderDeliveryError as exc:
+                reminder.failure_reason_code = exc.reason_code
+                stats.failure_reason_counts[exc.reason_code] += 1
+                if (
+                    exc.is_transient
+                    and reminder.attempt_count < selected_settings.reminder_retry_max_attempts
+                ):
+                    backoff_seconds = selected_settings.reminder_retry_backoff_seconds * (
+                        2 ** (reminder.attempt_count - 1)
+                    )
+                    reminder.next_attempt_at = now + timedelta(seconds=backoff_seconds)
+                    reminder.delivery_status = ReminderDeliveryStatus.retry_scheduled
+                    stats.retried += 1
+                    log_with_fields(
+                        logger,
+                        logging.WARNING,
+                        "reminder delivery transient failure",
+                        reminder_id=reminder.id,
+                        reason_code=exc.reason_code,
+                        attempt_count=reminder.attempt_count,
+                        next_attempt_at=reminder.next_attempt_at.isoformat(),
+                        backoff_seconds=backoff_seconds,
+                    )
+                else:
+                    reminder.delivery_status = ReminderDeliveryStatus.failed_terminal
+                    stats.failed += 1
+                    log_with_fields(
+                        logger,
+                        logging.ERROR,
+                        "reminder delivery terminal failure",
+                        reminder_id=reminder.id,
+                        reason_code=exc.reason_code,
+                        attempt_count=reminder.attempt_count,
+                    )
+                continue
+
+            reminder.sent_at = now
+            reminder.next_attempt_at = now
+            reminder.delivery_status = ReminderDeliveryStatus.sent
+            reminder.failure_reason_code = None
+            stats.sent += 1
+
+        await session.commit()
+
+    _log_run_summary(logger=logger, started_at=started_at, stats=stats)

--- a/src/agendable/services/reminder_delivery_service.py
+++ b/src/agendable/services/reminder_delivery_service.py
@@ -30,12 +30,14 @@ def _is_reminder_due(reminder: Reminder, now: datetime) -> bool:
 
 
 async def claim_reminder_attempt(*, reminder: Reminder, now: datetime) -> bool:
+    settings = get_settings()
     async with db.SessionMaker() as claim_session:
         reminder_repo = ReminderRepository(claim_session)
         was_claimed = await reminder_repo.try_claim_attempt(
             reminder_id=reminder.id,
             expected_attempt_count=reminder.attempt_count,
             now=now,
+            claim_lease_seconds=settings.reminder_claim_lease_seconds,
         )
         if not was_claimed:
             return False

--- a/src/agendable/settings.py
+++ b/src/agendable/settings.py
@@ -60,6 +60,8 @@ class Settings(BaseSettings):
     enable_default_email_reminders: bool = True
     default_email_reminder_minutes_before: int = 60
     reminder_worker_poll_seconds: int = 60
+    reminder_retry_max_attempts: int = Field(default=3, ge=1)
+    reminder_retry_backoff_seconds: int = Field(default=60, ge=1)
 
     # OIDC (optional)
     oidc_client_id: str | None = None

--- a/src/agendable/settings.py
+++ b/src/agendable/settings.py
@@ -62,6 +62,7 @@ class Settings(BaseSettings):
     reminder_worker_poll_seconds: int = 60
     reminder_retry_max_attempts: int = Field(default=3, ge=1)
     reminder_retry_backoff_seconds: int = Field(default=60, ge=1)
+    reminder_claim_lease_seconds: int = Field(default=30, ge=1)
 
     # OIDC (optional)
     oidc_client_id: str | None = None

--- a/src/agendable/web/routes/occurrences/router.py
+++ b/src/agendable/web/routes/occurrences/router.py
@@ -6,7 +6,6 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import Response
 
@@ -14,12 +13,12 @@ from agendable.auth import require_user
 from agendable.db import get_session
 from agendable.db.models import (
     AgendaItem,
-    MeetingOccurrenceAttendee,
     Task,
     User,
 )
 from agendable.db.repos import (
     AgendaItemRepository,
+    MeetingOccurrenceAttendeeRepository,
     MeetingOccurrenceRepository,
     TaskRepository,
     UserRepository,
@@ -219,17 +218,13 @@ async def add_attendee(
     if attendee_user is None:
         raise HTTPException(status_code=400, detail="Invalid attendee")
 
-    existing = (
-        await session.execute(
-            select(MeetingOccurrenceAttendee).where(
-                MeetingOccurrenceAttendee.occurrence_id == occurrence_id,
-                MeetingOccurrenceAttendee.user_id == attendee_user.id,
-            )
-        )
-    ).scalar_one_or_none()
+    attendee_repo = MeetingOccurrenceAttendeeRepository(session)
+    existing = await attendee_repo.get_by_occurrence_and_user(occurrence_id, attendee_user.id)
     if existing is None:
-        session.add(
-            MeetingOccurrenceAttendee(occurrence_id=occurrence_id, user_id=attendee_user.id)
+        await attendee_repo.add_link(
+            occurrence_id=occurrence_id,
+            user_id=attendee_user.id,
+            flush=False,
         )
         await session.commit()
         record_occurrence_activity(

--- a/src/agendable/web/routes/series.py
+++ b/src/agendable/web/routes/series.py
@@ -12,8 +12,12 @@ from starlette.responses import Response
 
 from agendable.auth import require_user
 from agendable.db import get_session
-from agendable.db.models import MeetingOccurrence, MeetingOccurrenceAttendee, User
-from agendable.db.repos import MeetingOccurrenceRepository, MeetingSeriesRepository
+from agendable.db.models import MeetingOccurrence, User
+from agendable.db.repos import (
+    MeetingOccurrenceAttendeeRepository,
+    MeetingOccurrenceRepository,
+    MeetingSeriesRepository,
+)
 from agendable.logging_config import log_with_fields
 from agendable.reminders import build_default_email_reminder
 from agendable.services import create_series_with_occurrences
@@ -214,13 +218,13 @@ async def create_series(
 
         attendee_user_ids.update(user.id for user in attendee_users)
 
+    attendee_repo = MeetingOccurrenceAttendeeRepository(session)
     for occurrence in occurrences:
         for attendee_user_id in attendee_user_ids:
-            session.add(
-                MeetingOccurrenceAttendee(
-                    occurrence_id=occurrence.id,
-                    user_id=attendee_user_id,
-                )
+            await attendee_repo.add_link(
+                occurrence_id=occurrence.id,
+                user_id=attendee_user_id,
+                flush=False,
             )
 
     await session.commit()
@@ -302,7 +306,7 @@ async def add_series_attendee(
         attendee_user_id=attendee_user.id,
         occurrence_ids=occurrence_ids,
     )
-    added_count = add_missing_attendee_links(
+    added_count = await add_missing_attendee_links(
         session=session,
         attendee_user_id=attendee_user.id,
         occurrence_ids=occurrence_ids,

--- a/src/agendable/web/routes/series_helpers.py
+++ b/src/agendable/web/routes/series_helpers.py
@@ -5,11 +5,15 @@ from datetime import UTC, datetime
 
 from fastapi import HTTPException, Request
 from fastapi.responses import HTMLResponse
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from agendable.db.models import MeetingOccurrence, MeetingOccurrenceAttendee, MeetingSeries, User
-from agendable.db.repos import MeetingOccurrenceRepository, MeetingSeriesRepository
+from agendable.db.models import MeetingOccurrence, MeetingSeries, User
+from agendable.db.repos import (
+    MeetingOccurrenceAttendeeRepository,
+    MeetingOccurrenceRepository,
+    MeetingSeriesRepository,
+    UserRepository,
+)
 from agendable.recurrence import build_rrule
 from agendable.web.routes.common import recurrence_label, templates
 
@@ -173,8 +177,8 @@ async def resolve_series_attendee_user(
     session: AsyncSession,
     email: str,
 ) -> User | None:
-    result = await session.execute(select(User).where(User.email == email))
-    return result.scalar_one_or_none()
+    users_repo = UserRepository(session)
+    return await users_repo.get_by_email(email)
 
 
 async def existing_attendee_occurrence_ids(
@@ -183,33 +187,23 @@ async def existing_attendee_occurrence_ids(
     attendee_user_id: uuid.UUID,
     occurrence_ids: list[uuid.UUID],
 ) -> set[uuid.UUID]:
-    if not occurrence_ids:
-        return set()
-
-    existing_links = (
-        await session.execute(
-            select(MeetingOccurrenceAttendee.occurrence_id).where(
-                MeetingOccurrenceAttendee.user_id == attendee_user_id,
-                MeetingOccurrenceAttendee.occurrence_id.in_(occurrence_ids),
-            )
-        )
-    ).scalars()
-    return set(existing_links)
+    attendee_repo = MeetingOccurrenceAttendeeRepository(session)
+    return await attendee_repo.list_occurrence_ids_for_user(
+        user_id=attendee_user_id,
+        occurrence_ids=occurrence_ids,
+    )
 
 
-def add_missing_attendee_links(
+async def add_missing_attendee_links(
     *,
     session: AsyncSession,
     attendee_user_id: uuid.UUID,
     occurrence_ids: list[uuid.UUID],
     existing_occurrence_ids: set[uuid.UUID],
 ) -> int:
-    added_count = 0
-    for occurrence_id in occurrence_ids:
-        if occurrence_id in existing_occurrence_ids:
-            continue
-        session.add(
-            MeetingOccurrenceAttendee(occurrence_id=occurrence_id, user_id=attendee_user_id)
-        )
-        added_count += 1
-    return added_count
+    attendee_repo = MeetingOccurrenceAttendeeRepository(session)
+    return await attendee_repo.add_missing_links(
+        user_id=attendee_user_id,
+        occurrence_ids=occurrence_ids,
+        existing_occurrence_ids=existing_occurrence_ids,
+    )

--- a/tests/repos/test_meeting_occurrence_attendee_repo.py
+++ b/tests/repos/test_meeting_occurrence_attendee_repo.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import agendable.db as db
+from agendable.db.models import MeetingOccurrence, MeetingSeries, User
+from agendable.db.repos.meeting_occurrence_attendees import MeetingOccurrenceAttendeeRepository
+from agendable.db.repos.users import UserRepository
+
+
+async def _new_user(email: str) -> User:
+    return User(
+        email=email,
+        first_name="Test",
+        last_name="User",
+        display_name="Test User",
+        timezone="UTC",
+        password_hash=None,
+    )
+
+
+async def _create_occurrence(
+    db_session: AsyncSession, owner_user_id: uuid.UUID
+) -> MeetingOccurrence:
+    series = MeetingSeries(owner_user_id=owner_user_id, title="Weekly", default_interval_days=7)
+    db_session.add(series)
+    await db_session.flush()
+
+    occurrence = MeetingOccurrence(
+        series_id=series.id,
+        scheduled_at=datetime.now(UTC) + timedelta(days=1),
+        notes="",
+        is_completed=False,
+    )
+    db_session.add(occurrence)
+    await db_session.flush()
+    return occurrence
+
+
+@pytest.mark.asyncio
+async def test_attendee_repo_get_and_list_occurrence_ids(db_session: AsyncSession) -> None:
+    users_repo = UserRepository(db_session)
+    owner = await _new_user(f"owner-{uuid.uuid4()}@example.com")
+    attendee = await _new_user(f"attendee-{uuid.uuid4()}@example.com")
+    await users_repo.add(owner)
+    await users_repo.add(attendee)
+    await users_repo.commit()
+
+    occ_one = await _create_occurrence(db_session, owner.id)
+    occ_two = await _create_occurrence(db_session, owner.id)
+
+    repo = MeetingOccurrenceAttendeeRepository(db_session)
+    await repo.add_link(occurrence_id=occ_one.id, user_id=attendee.id)
+    await repo.commit()
+
+    got = await repo.get_by_occurrence_and_user(occ_one.id, attendee.id)
+    assert got is not None
+
+    missing = await repo.get_by_occurrence_and_user(occ_two.id, attendee.id)
+    assert missing is None
+
+    linked_ids = await repo.list_occurrence_ids_for_user(
+        user_id=attendee.id,
+        occurrence_ids=[occ_one.id, occ_two.id],
+    )
+    assert linked_ids == {occ_one.id}
+
+
+@pytest.mark.asyncio
+async def test_attendee_repo_add_missing_links(db_session: AsyncSession) -> None:
+    users_repo = UserRepository(db_session)
+    owner = await _new_user(f"owner-{uuid.uuid4()}@example.com")
+    attendee = await _new_user(f"attendee-{uuid.uuid4()}@example.com")
+    await users_repo.add(owner)
+    await users_repo.add(attendee)
+    await users_repo.commit()
+
+    occ_one = await _create_occurrence(db_session, owner.id)
+    occ_two = await _create_occurrence(db_session, owner.id)
+
+    repo = MeetingOccurrenceAttendeeRepository(db_session)
+    await repo.add_link(occurrence_id=occ_one.id, user_id=attendee.id)
+    await repo.commit()
+
+    existing = await repo.list_occurrence_ids_for_user(
+        user_id=attendee.id,
+        occurrence_ids=[occ_one.id, occ_two.id],
+    )
+
+    added = await repo.add_missing_links(
+        user_id=attendee.id,
+        occurrence_ids=[occ_one.id, occ_two.id],
+        existing_occurrence_ids=existing,
+    )
+    await repo.commit()
+
+    assert added == 1
+
+    async with db.SessionMaker() as verify_session:
+        verify_repo = MeetingOccurrenceAttendeeRepository(verify_session)
+        linked_ids = await verify_repo.list_occurrence_ids_for_user(
+            user_id=attendee.id,
+            occurrence_ids=[occ_one.id, occ_two.id],
+        )
+        assert linked_ids == {occ_one.id, occ_two.id}
+
+        all_rows = await verify_repo.list(limit=10)
+        attendee_rows = [
+            row
+            for row in all_rows
+            if row.user_id == attendee.id and row.occurrence_id in {occ_one.id, occ_two.id}
+        ]
+        assert len(attendee_rows) == 2

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -19,11 +19,13 @@ from agendable.db.models import (
     Task,
     User,
 )
+from agendable.db.repos import ReminderRepository
 from agendable.reminders import (
     ReminderEmail,
     ReminderSender,
     TerminalReminderDeliveryError,
     TransientReminderDeliveryError,
+    as_utc,
 )
 
 
@@ -343,3 +345,57 @@ async def test_run_due_reminders_skips_send_when_claim_not_acquired(
         ).scalar_one()
         assert refreshed.sent_at is None
         assert refreshed.attempt_count == 0
+
+
+@pytest.mark.asyncio
+async def test_try_claim_attempt_applies_lease_and_blocks_immediate_reclaim(
+    db_session: AsyncSession,
+) -> None:
+    occurrence = await _create_occurrence(
+        db_session,
+        email="owner-lease@example.com",
+        title="Lease Meeting",
+    )
+
+    reminder = Reminder(
+        occurrence_id=occurrence.id,
+        channel=ReminderChannel.email,
+        send_at=datetime.now(UTC) - timedelta(minutes=1),
+        next_attempt_at=datetime.now(UTC) - timedelta(minutes=1),
+        sent_at=None,
+    )
+    db_session.add(reminder)
+    await db_session.commit()
+
+    async with db.SessionMaker() as claim_session:
+        repo = ReminderRepository(claim_session)
+        claim_now = datetime.now(UTC)
+        first_claim = await repo.try_claim_attempt(
+            reminder_id=reminder.id,
+            expected_attempt_count=0,
+            now=claim_now,
+            claim_lease_seconds=45,
+        )
+        await claim_session.commit()
+
+    assert first_claim is True
+
+    async with db.SessionMaker() as verify_session:
+        refreshed = (
+            await verify_session.execute(select(Reminder).where(Reminder.id == reminder.id))
+        ).scalar_one()
+        assert refreshed.attempt_count == 1
+        assert refreshed.next_attempt_at is not None
+        assert as_utc(refreshed.next_attempt_at) > claim_now
+
+    async with db.SessionMaker() as second_claim_session:
+        repo = ReminderRepository(second_claim_session)
+        second_claim = await repo.try_claim_attempt(
+            reminder_id=reminder.id,
+            expected_attempt_count=1,
+            now=claim_now,
+            claim_lease_seconds=45,
+        )
+        await second_claim_session.commit()
+
+    assert second_claim is False

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -325,8 +325,7 @@ async def test_run_due_reminders_skips_send_when_claim_not_acquired(
     db_session.add(reminder)
     await db_session.commit()
 
-    async def fake_claim(*, session: AsyncSession, reminder: Reminder, now: datetime) -> bool:
-        _ = session
+    async def fake_claim(*, reminder: Reminder, now: datetime) -> bool:
         _ = reminder
         _ = now
         return False

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -7,6 +7,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+import agendable.cli as reminder_cli
 import agendable.db as db
 from agendable.cli import _run_due_reminders
 from agendable.db.models import (
@@ -14,10 +15,16 @@ from agendable.db.models import (
     MeetingSeries,
     Reminder,
     ReminderChannel,
+    ReminderDeliveryStatus,
     Task,
     User,
 )
-from agendable.reminders import ReminderEmail, ReminderSender
+from agendable.reminders import (
+    ReminderEmail,
+    ReminderSender,
+    TerminalReminderDeliveryError,
+    TransientReminderDeliveryError,
+)
 
 
 @dataclass
@@ -26,6 +33,24 @@ class CapturingSender(ReminderSender):
 
     async def send_email_reminder(self, reminder: ReminderEmail) -> None:
         self.sent.append(reminder)
+
+
+@dataclass
+class TransientFailingSender(ReminderSender):
+    reason_code: str
+
+    async def send_email_reminder(self, reminder: ReminderEmail) -> None:
+        _ = reminder
+        raise TransientReminderDeliveryError(self.reason_code)
+
+
+@dataclass
+class TerminalFailingSender(ReminderSender):
+    reason_code: str
+
+    async def send_email_reminder(self, reminder: ReminderEmail) -> None:
+        _ = reminder
+        raise TerminalReminderDeliveryError(self.reason_code)
 
 
 async def _create_occurrence(
@@ -122,6 +147,8 @@ async def test_run_due_reminders_sends_due_email_and_marks_sent(db_session: Asyn
         ).scalar_one()
 
         assert refreshed_due.sent_at is not None
+        assert refreshed_due.delivery_status == ReminderDeliveryStatus.sent
+        assert refreshed_due.failure_reason_code is None
         assert refreshed_future.sent_at is None
 
 
@@ -152,3 +179,168 @@ async def test_run_due_reminders_skips_non_email_channels(db_session: AsyncSessi
             await verify_session.execute(select(Reminder).where(Reminder.id == slack_reminder.id))
         ).scalar_one()
         assert refreshed.sent_at is None
+        assert refreshed.delivery_status == ReminderDeliveryStatus.skipped
+        assert refreshed.failure_reason_code == "unsupported_channel"
+
+
+@pytest.mark.asyncio
+async def test_run_due_reminders_transient_failure_schedules_retry(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENDABLE_REMINDER_RETRY_MAX_ATTEMPTS", "3")
+    monkeypatch.setenv("AGENDABLE_REMINDER_RETRY_BACKOFF_SECONDS", "30")
+
+    occurrence = await _create_occurrence(
+        db_session,
+        email="owner-retry@example.com",
+        title="Retry Meeting",
+    )
+
+    retry_reminder = Reminder(
+        occurrence_id=occurrence.id,
+        channel=ReminderChannel.email,
+        send_at=datetime.now(UTC) - timedelta(minutes=2),
+        next_attempt_at=datetime.now(UTC) - timedelta(minutes=1),
+        sent_at=None,
+    )
+    db_session.add(retry_reminder)
+    await db_session.commit()
+
+    await _run_due_reminders(sender=TransientFailingSender(reason_code="smtp_unavailable"))
+
+    async with db.SessionMaker() as verify_session:
+        refreshed = (
+            await verify_session.execute(select(Reminder).where(Reminder.id == retry_reminder.id))
+        ).scalar_one()
+
+        assert refreshed.sent_at is None
+        assert refreshed.delivery_status == ReminderDeliveryStatus.retry_scheduled
+        assert refreshed.failure_reason_code == "smtp_unavailable"
+        assert refreshed.attempt_count == 1
+        assert refreshed.last_attempted_at is not None
+        assert refreshed.next_attempt_at is not None
+        assert refreshed.next_attempt_at > refreshed.last_attempted_at
+        retry_delay = (refreshed.next_attempt_at - refreshed.last_attempted_at).total_seconds()
+        assert retry_delay == pytest.approx(30, rel=0, abs=1)
+
+
+@pytest.mark.asyncio
+async def test_run_due_reminders_terminal_failure_marks_failed(
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level("INFO", logger="agendable.cli")
+    occurrence = await _create_occurrence(
+        db_session,
+        email="owner-failed@example.com",
+        title="Failure Meeting",
+    )
+
+    failed_reminder = Reminder(
+        occurrence_id=occurrence.id,
+        channel=ReminderChannel.email,
+        send_at=datetime.now(UTC) - timedelta(minutes=1),
+        next_attempt_at=datetime.now(UTC) - timedelta(minutes=1),
+        sent_at=None,
+    )
+    db_session.add(failed_reminder)
+    await db_session.commit()
+
+    await _run_due_reminders(sender=TerminalFailingSender(reason_code="smtp_auth_failed"))
+
+    async with db.SessionMaker() as verify_session:
+        refreshed = (
+            await verify_session.execute(select(Reminder).where(Reminder.id == failed_reminder.id))
+        ).scalar_one()
+
+        assert refreshed.delivery_status == ReminderDeliveryStatus.failed_terminal
+        assert refreshed.failure_reason_code == "smtp_auth_failed"
+        assert refreshed.attempt_count == 1
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("reminder run complete" in message for message in messages)
+    assert any("attempted=1" in message for message in messages)
+    assert any("failed=1" in message for message in messages)
+    assert any("reminder run failure reason" in message for message in messages)
+    assert any("reason_code=smtp_auth_failed" in message for message in messages)
+
+
+@pytest.mark.asyncio
+async def test_run_due_reminders_stops_retrying_at_max_attempts(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENDABLE_REMINDER_RETRY_MAX_ATTEMPTS", "2")
+    monkeypatch.setenv("AGENDABLE_REMINDER_RETRY_BACKOFF_SECONDS", "15")
+
+    occurrence = await _create_occurrence(
+        db_session,
+        email="owner-max@example.com",
+        title="Max Attempts Meeting",
+    )
+
+    maxed_reminder = Reminder(
+        occurrence_id=occurrence.id,
+        channel=ReminderChannel.email,
+        send_at=datetime.now(UTC) - timedelta(minutes=2),
+        next_attempt_at=datetime.now(UTC) - timedelta(minutes=1),
+        sent_at=None,
+        attempt_count=1,
+        delivery_status=ReminderDeliveryStatus.retry_scheduled,
+    )
+    db_session.add(maxed_reminder)
+    await db_session.commit()
+
+    await _run_due_reminders(sender=TransientFailingSender(reason_code="smtp_unavailable"))
+
+    async with db.SessionMaker() as verify_session:
+        refreshed = (
+            await verify_session.execute(select(Reminder).where(Reminder.id == maxed_reminder.id))
+        ).scalar_one()
+
+        assert refreshed.delivery_status == ReminderDeliveryStatus.failed_terminal
+        assert refreshed.attempt_count == 2
+        assert refreshed.failure_reason_code == "smtp_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_run_due_reminders_skips_send_when_claim_not_acquired(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    occurrence = await _create_occurrence(
+        db_session,
+        email="owner-claim@example.com",
+        title="Claimed Elsewhere Meeting",
+    )
+
+    reminder = Reminder(
+        occurrence_id=occurrence.id,
+        channel=ReminderChannel.email,
+        send_at=datetime.now(UTC) - timedelta(minutes=1),
+        next_attempt_at=datetime.now(UTC) - timedelta(minutes=1),
+        sent_at=None,
+    )
+    db_session.add(reminder)
+    await db_session.commit()
+
+    async def fake_claim(*, session: AsyncSession, reminder: Reminder, now: datetime) -> bool:
+        _ = session
+        _ = reminder
+        _ = now
+        return False
+
+    monkeypatch.setattr(reminder_cli, "_claim_reminder_attempt", fake_claim)
+
+    sender = CapturingSender(sent=[])
+    await _run_due_reminders(sender=sender)
+
+    assert sender.sent == []
+
+    async with db.SessionMaker() as verify_session:
+        refreshed = (
+            await verify_session.execute(select(Reminder).where(Reminder.id == reminder.id))
+        ).scalar_one()
+        assert refreshed.sent_at is None
+        assert refreshed.attempt_count == 0


### PR DESCRIPTION
## Summary
<!-- What does this PR change, and why? Keep it brief. -->

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Docs only
- [ ] CI / build / tooling
- [ ] Other (please describe):

## Testing
<!-- Check what you actually ran. -->
- [X] Unit tests
- [ ] Integration tests
- [X] Lint / formatting
- [ ] Manual testing

## Data / config impact
- [X] Alembic migration included
- [ ] No migration needed (schema unchanged)
- [X] New/changed env vars documented (README/PR notes)
- [ ] No config/env var changes

## Checklist
- [X] I kept the change scoped and easy to review
- [X] I updated or added tests where it made sense
- [X] I updated docs / comments where needed
- [X] CI is green (or I explained why it isn’t)
- [X] No secrets or credentials were committed

## Summary
- Adds bounded retry behavior for reminder delivery with configurable max attempts and exponential backoff.
- Distinguishes transient vs terminal delivery failures and records reason codes for failure visibility.
- Adds idempotent claim-before-send flow to prevent duplicate sends in concurrent worker scenarios.
- Adds per-run reminder summary logging with parseable counters: attempted, sent, failed, skipped, retried, plus duration.
- Extends reminder delivery state in persistence (attempt tracking, next attempt, last attempted, delivery status, failure reason).
- Introduces/expands repository coverage for reminders and occurrence attendees to centralize CRUD/query logic.
- Extracts reminder delivery business logic into a service layer and keeps CLI focused on orchestration.
- Updates contributor guidance to clarify layer boundaries (entrypoint/service/repo/adapter).

Closes #15
Closes #16