### PR TITLE
Add opt-in for series in calendar sync

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: auto
+        target: 85%
         threshold: 0.1%
     patch:
       default:

--- a/migrations/versions/0018_imported_series_review_decisions.py
+++ b/migrations/versions/0018_imported_series_review_decisions.py
@@ -1,0 +1,98 @@
+"""Add imported-series review decision fields.
+
+Revision ID: 0018
+Revises: 0017
+Create Date: 2026-03-11
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "0018"
+down_revision = "0017"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    import_decision_enum = sa.Enum(
+        "pending",
+        "kept",
+        "rejected",
+        name="imported_series_decision",
+    )
+
+    if bind.dialect.name == "postgresql":
+        op.execute(
+            """
+            DO $$
+            BEGIN
+                CREATE TYPE imported_series_decision AS ENUM ('pending', 'kept', 'rejected');
+            EXCEPTION
+                WHEN duplicate_object THEN NULL;
+            END
+            $$;
+            """
+        )
+        import_decision_column_type = postgresql.ENUM(
+            "pending",
+            "kept",
+            "rejected",
+            name="imported_series_decision",
+            create_type=False,
+        )
+        provider_column_type = postgresql.ENUM(
+            "google",
+            name="calendar_provider",
+            create_type=False,
+        )
+    else:
+        import_decision_enum.create(bind, checkfirst=True)
+        import_decision_column_type = import_decision_enum
+        provider_column_type = sa.Enum("google", name="calendar_provider")
+
+    op.add_column(
+        "meeting_series",
+        sa.Column(
+            "imported_from_provider",
+            provider_column_type,
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "meeting_series",
+        sa.Column("import_external_series_id", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "meeting_series",
+        sa.Column("import_decision", import_decision_column_type, nullable=True),
+    )
+    op.create_index(
+        op.f("ix_meeting_series_import_external_series_id"),
+        "meeting_series",
+        ["import_external_series_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_meeting_series_import_external_series_id"),
+        table_name="meeting_series",
+    )
+    op.drop_column("meeting_series", "import_decision")
+    op.drop_column("meeting_series", "import_external_series_id")
+    op.drop_column("meeting_series", "imported_from_provider")
+
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("DROP TYPE IF EXISTS imported_series_decision")
+    else:
+        import_decision_enum = sa.Enum(name="imported_series_decision")
+        import_decision_enum.drop(bind, checkfirst=True)

--- a/src/agendable/db/models.py
+++ b/src/agendable/db/models.py
@@ -44,6 +44,12 @@ class CalendarProvider(enum.StrEnum):
     google = "google"
 
 
+class ImportedSeriesDecision(enum.StrEnum):
+    pending = "pending"
+    kept = "kept"
+    rejected = "rejected"
+
+
 class User(Base):
     __tablename__ = "users"
 
@@ -124,6 +130,16 @@ class MeetingSeries(Base):
         DateTime(timezone=True), nullable=True
     )
     recurrence_timezone: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+    imported_from_provider: Mapped[CalendarProvider | None] = mapped_column(
+        Enum(CalendarProvider, name="calendar_provider"),
+        nullable=True,
+    )
+    import_external_series_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    import_decision: Mapped[ImportedSeriesDecision | None] = mapped_column(
+        Enum(ImportedSeriesDecision, name="imported_series_decision"),
+        nullable=True,
+    )
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(UTC)

--- a/src/agendable/db/repos/meeting_series.py
+++ b/src/agendable/db/repos/meeting_series.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import uuid
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from agendable.db.models import MeetingSeries
+from agendable.db.models import ImportedSeriesDecision, MeetingSeries
 from agendable.db.repos.base import BaseRepository
 
 
@@ -16,7 +16,13 @@ class MeetingSeriesRepository(BaseRepository[MeetingSeries]):
     async def list_for_owner(self, owner_user_id: uuid.UUID) -> list[MeetingSeries]:
         result = await self.session.execute(
             select(MeetingSeries)
-            .where(MeetingSeries.owner_user_id == owner_user_id)
+            .where(
+                MeetingSeries.owner_user_id == owner_user_id,
+                or_(
+                    MeetingSeries.import_decision.is_(None),
+                    MeetingSeries.import_decision == ImportedSeriesDecision.kept,
+                ),
+            )
             .order_by(MeetingSeries.created_at.desc())
         )
         return list(result.scalars().all())

--- a/src/agendable/services/calendar_event_mapping_service.py
+++ b/src/agendable/services/calendar_event_mapping_service.py
@@ -7,8 +7,10 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from agendable.db.models import (
+    CalendarProvider,
     ExternalCalendarConnection,
     ExternalCalendarEventMirror,
+    ImportedSeriesDecision,
     MeetingOccurrence,
     MeetingSeries,
 )
@@ -74,6 +76,12 @@ class CalendarEventMappingService:
             recurring_event_details_by_id=recurring_event_details_by_id,
         )
 
+        if series.import_decision in {
+            ImportedSeriesDecision.pending,
+            ImportedSeriesDecision.rejected,
+        }:
+            return 0
+
         occurrence = linked_occurrence
         if occurrence is None:
             occurrence = await self._find_occurrence_by_schedule(
@@ -123,12 +131,25 @@ class CalendarEventMappingService:
                 return existing_series
 
         group_key = self._series_group_key(mirror)
+        existing_series = await self._find_series_for_import_key(
+            owner_user_id=connection.user_id,
+            import_external_series_id=group_key,
+        )
+        if existing_series is not None:
+            self._apply_series_title(existing_series, mirror)
+            self._apply_series_recurrence(existing_series, mirror, recurring_event_details_by_id)
+            return existing_series
+
         existing_series = await self._find_series_for_group_key(
             connection_id=connection.id,
             group_key=group_key,
             is_recurring=mirror.external_recurring_event_id is not None,
         )
         if existing_series is not None:
+            existing_series.imported_from_provider = CalendarProvider.google
+            existing_series.import_external_series_id = group_key
+            if existing_series.import_decision is None:
+                existing_series.import_decision = ImportedSeriesDecision.kept
             self._apply_series_title(existing_series, mirror)
             self._apply_series_recurrence(existing_series, mirror, recurring_event_details_by_id)
             return existing_series
@@ -138,11 +159,32 @@ class CalendarEventMappingService:
             title=self._series_title(mirror),
             default_interval_days=7,
             reminder_minutes_before=60,
+            imported_from_provider=CalendarProvider.google,
+            import_external_series_id=group_key,
+            import_decision=ImportedSeriesDecision.pending,
         )
         self._apply_series_recurrence(series, mirror, recurring_event_details_by_id)
         self.session.add(series)
         await self.session.flush()
         return series
+
+    async def _find_series_for_import_key(
+        self,
+        *,
+        owner_user_id: uuid.UUID,
+        import_external_series_id: str,
+    ) -> MeetingSeries | None:
+        result = await self.session.execute(
+            select(MeetingSeries)
+            .where(
+                MeetingSeries.owner_user_id == owner_user_id,
+                MeetingSeries.imported_from_provider == CalendarProvider.google,
+                MeetingSeries.import_external_series_id == import_external_series_id,
+            )
+            .order_by(MeetingSeries.created_at.asc())
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
 
     def _apply_series_recurrence(
         self,

--- a/src/agendable/web/routes/auth/oidc.py
+++ b/src/agendable/web/routes/auth/oidc.py
@@ -5,12 +5,20 @@ import uuid
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request
 from fastapi.responses import RedirectResponse
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import Response
 
 from agendable.auth import require_user, verify_password
 from agendable.db import get_session
-from agendable.db.models import CalendarProvider, User
+from agendable.db.models import (
+    CalendarProvider,
+    ExternalCalendarEventMirror,
+    ImportedSeriesDecision,
+    MeetingOccurrence,
+    MeetingSeries,
+    User,
+)
 from agendable.db.repos import (
     ExternalCalendarConnectionRepository,
     ExternalCalendarEventMirrorRepository,
@@ -329,6 +337,115 @@ async def sync_google_calendar_now(
             synced_event_count=synced_event_count,
         )
 
+    return RedirectResponse(url="/profile", status_code=303)
+
+
+@router.post(
+    "/profile/calendar/google/import-series/{series_id}/keep",
+    response_class=RedirectResponse,
+)
+async def keep_google_imported_series(
+    series_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_user),
+) -> RedirectResponse:
+    series = await session.get(MeetingSeries, series_id)
+    if series is None or series.owner_user_id != current_user.id:
+        raise HTTPException(status_code=404)
+
+    if (
+        series.imported_from_provider != CalendarProvider.google
+        or series.import_decision != ImportedSeriesDecision.pending
+    ):
+        raise HTTPException(status_code=404)
+
+    connection_repo = ExternalCalendarConnectionRepository(session)
+    connection = await connection_repo.get_for_user_provider_calendar(
+        user_id=current_user.id,
+        provider=CalendarProvider.google,
+        external_calendar_id="primary",
+    )
+    if connection is None:
+        raise HTTPException(status_code=400, detail="No Google Calendar connection found")
+
+    series.import_decision = ImportedSeriesDecision.kept
+
+    import_series_id = series.import_external_series_id
+    if import_series_id:
+        mirrors = list(
+            (
+                await session.execute(
+                    select(ExternalCalendarEventMirror)
+                    .where(
+                        ExternalCalendarEventMirror.connection_id == connection.id,
+                        ExternalCalendarEventMirror.external_recurring_event_id == import_series_id,
+                    )
+                    .order_by(ExternalCalendarEventMirror.created_at.asc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if mirrors:
+            await CalendarEventMappingService(session=session).map_mirrors(
+                connection=connection,
+                mirrors=mirrors,
+                recurring_event_details_by_id=None,
+            )
+
+    await session.commit()
+    return RedirectResponse(url="/profile", status_code=303)
+
+
+@router.post(
+    "/profile/calendar/google/import-series/{series_id}/reject",
+    response_class=RedirectResponse,
+)
+async def reject_google_imported_series(
+    series_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(require_user),
+) -> RedirectResponse:
+    series = await session.get(MeetingSeries, series_id)
+    if series is None or series.owner_user_id != current_user.id:
+        raise HTTPException(status_code=404)
+
+    if series.imported_from_provider != CalendarProvider.google:
+        raise HTTPException(status_code=404)
+
+    # Keep the series row as a tombstone so this external recurring ID stays rejected.
+    series.import_decision = ImportedSeriesDecision.rejected
+
+    mirrors = list(
+        (
+            await session.execute(
+                select(ExternalCalendarEventMirror)
+                .join(
+                    MeetingOccurrence,
+                    ExternalCalendarEventMirror.linked_occurrence_id == MeetingOccurrence.id,
+                )
+                .where(MeetingOccurrence.series_id == series.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for mirror in mirrors:
+        mirror.linked_occurrence_id = None
+
+    occurrences = list(
+        (
+            await session.execute(
+                select(MeetingOccurrence).where(MeetingOccurrence.series_id == series.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for occurrence in occurrences:
+        await session.delete(occurrence)
+
+    await session.commit()
     return RedirectResponse(url="/profile", status_code=303)
 
 

--- a/src/agendable/web/routes/auth/oidc.py
+++ b/src/agendable/web/routes/auth/oidc.py
@@ -345,12 +345,19 @@ async def sync_google_calendar_now(
     response_class=RedirectResponse,
 )
 async def keep_google_imported_series(
+    request: Request,
     series_id: uuid.UUID,
     session: AsyncSession = Depends(get_session),
     current_user: User = Depends(require_user),
-) -> RedirectResponse:
+) -> Response:
+    settings = get_settings()
+    if not settings.google_calendar_sync_enabled:
+        raise HTTPException(status_code=404)
+
+    user = await auth_routes.get_user_or_404(session, current_user.id)
+
     series = await session.get(MeetingSeries, series_id)
-    if series is None or series.owner_user_id != current_user.id:
+    if series is None or series.owner_user_id != user.id:
         raise HTTPException(status_code=404)
 
     if (
@@ -361,12 +368,18 @@ async def keep_google_imported_series(
 
     connection_repo = ExternalCalendarConnectionRepository(session)
     connection = await connection_repo.get_for_user_provider_calendar(
-        user_id=current_user.id,
+        user_id=user.id,
         provider=CalendarProvider.google,
         external_calendar_id="primary",
     )
     if connection is None:
-        raise HTTPException(status_code=400, detail="No Google Calendar connection found")
+        return await auth_routes.render_profile_template(
+            request,
+            session=session,
+            user=user,
+            identity_error="No Google Calendar connection found yet.",
+            status_code=400,
+        )
 
     series.import_decision = ImportedSeriesDecision.kept
 
@@ -406,11 +419,18 @@ async def reject_google_imported_series(
     session: AsyncSession = Depends(get_session),
     current_user: User = Depends(require_user),
 ) -> RedirectResponse:
+    settings = get_settings()
+    if not settings.google_calendar_sync_enabled:
+        raise HTTPException(status_code=404)
+
     series = await session.get(MeetingSeries, series_id)
     if series is None or series.owner_user_id != current_user.id:
         raise HTTPException(status_code=404)
 
-    if series.imported_from_provider != CalendarProvider.google:
+    if (
+        series.imported_from_provider != CalendarProvider.google
+        or series.import_decision != ImportedSeriesDecision.pending
+    ):
         raise HTTPException(status_code=404)
 
     # Keep the series row as a tombstone so this external recurring ID stays rejected.

--- a/src/agendable/web/routes/auth/router.py
+++ b/src/agendable/web/routes/auth/router.py
@@ -197,30 +197,33 @@ async def render_profile_template(
         provider=CalendarProvider.google,
         external_calendar_id="primary",
     )
-    pending_import_series = list(
-        (
-            await session.execute(
-                select(MeetingSeries)
-                .where(
-                    MeetingSeries.owner_user_id == user.id,
-                    MeetingSeries.imported_from_provider == CalendarProvider.google,
-                    MeetingSeries.import_decision == ImportedSeriesDecision.pending,
+    pending_import_series: list[MeetingSeries] = []
+    pending_import_recurrence: dict[uuid.UUID, str] = {}
+    if settings.google_calendar_sync_enabled:
+        pending_import_series = list(
+            (
+                await session.execute(
+                    select(MeetingSeries)
+                    .where(
+                        MeetingSeries.owner_user_id == user.id,
+                        MeetingSeries.imported_from_provider == CalendarProvider.google,
+                        MeetingSeries.import_decision == ImportedSeriesDecision.pending,
+                    )
+                    .order_by(MeetingSeries.created_at.desc())
                 )
-                .order_by(MeetingSeries.created_at.desc())
             )
+            .scalars()
+            .all()
         )
-        .scalars()
-        .all()
-    )
-    pending_import_recurrence = {
-        series.id: recurrence_label(
-            recurrence_rrule=series.recurrence_rrule,
-            recurrence_dtstart=series.recurrence_dtstart,
-            recurrence_timezone=series.recurrence_timezone,
-            default_interval_days=series.default_interval_days,
-        )
-        for series in pending_import_series
-    }
+        pending_import_recurrence = {
+            series.id: recurrence_label(
+                recurrence_rrule=series.recurrence_rrule,
+                recurrence_dtstart=series.recurrence_dtstart,
+                recurrence_timezone=series.recurrence_timezone,
+                default_interval_days=series.default_interval_days,
+            )
+            for series in pending_import_series
+        }
 
     return templates.TemplateResponse(
         request,

--- a/src/agendable/web/routes/auth/router.py
+++ b/src/agendable/web/routes/auth/router.py
@@ -7,12 +7,19 @@ from urllib.parse import unquote
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import Response
 
 from agendable.auth import hash_password, require_user, verify_password
 from agendable.db import get_session
-from agendable.db.models import CalendarProvider, User, UserRole
+from agendable.db.models import (
+    CalendarProvider,
+    ImportedSeriesDecision,
+    MeetingSeries,
+    User,
+    UserRole,
+)
 from agendable.db.repos import (
     ExternalCalendarConnectionRepository,
     ExternalIdentityRepository,
@@ -33,7 +40,7 @@ from agendable.settings import get_settings
 from agendable.sso.oidc.client import OidcClient
 from agendable.web.routes.auth.oidc import router as auth_oidc_router
 from agendable.web.routes.auth.rate_limits import is_login_rate_limited, record_login_failure
-from agendable.web.routes.common import oauth, parse_timezone, templates
+from agendable.web.routes.common import oauth, parse_timezone, recurrence_label, templates
 
 router = APIRouter()
 logger = logging.getLogger("uvicorn.error")
@@ -190,6 +197,31 @@ async def render_profile_template(
         provider=CalendarProvider.google,
         external_calendar_id="primary",
     )
+    pending_import_series = list(
+        (
+            await session.execute(
+                select(MeetingSeries)
+                .where(
+                    MeetingSeries.owner_user_id == user.id,
+                    MeetingSeries.imported_from_provider == CalendarProvider.google,
+                    MeetingSeries.import_decision == ImportedSeriesDecision.pending,
+                )
+                .order_by(MeetingSeries.created_at.desc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    pending_import_recurrence = {
+        series.id: recurrence_label(
+            recurrence_rrule=series.recurrence_rrule,
+            recurrence_dtstart=series.recurrence_dtstart,
+            recurrence_timezone=series.recurrence_timezone,
+            default_interval_days=series.default_interval_days,
+        )
+        for series in pending_import_series
+    }
+
     return templates.TemplateResponse(
         request,
         "profile.html",
@@ -203,6 +235,8 @@ async def render_profile_template(
             "any_oidc_enabled": _auth_oidc_enabled() or _auth_keycloak_oidc_enabled(),
             "google_calendar_sync_enabled": settings.google_calendar_sync_enabled,
             "google_calendar_connected": google_calendar_connection is not None,
+            "pending_import_series": pending_import_series,
+            "pending_import_recurrence": pending_import_recurrence,
         },
         status_code=status_code,
     )

--- a/src/agendable/web/routes/dashboard.py
+++ b/src/agendable/web/routes/dashboard.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import selectinload
 from agendable.auth import require_user
 from agendable.db import get_session
 from agendable.db.models import (
+    ImportedSeriesDecision,
     MeetingOccurrence,
     MeetingOccurrenceAttendee,
     MeetingSeries,
@@ -48,6 +49,10 @@ async def dashboard(
                         MeetingSeries.owner_user_id == current_user.id,
                         MeetingOccurrenceAttendee.user_id == current_user.id,
                     ),
+                    or_(
+                        MeetingSeries.import_decision.is_(None),
+                        MeetingSeries.import_decision == ImportedSeriesDecision.kept,
+                    ),
                     MeetingOccurrence.scheduled_at >= now,
                 )
                 .distinct()
@@ -77,6 +82,10 @@ async def dashboard(
                     or_(
                         MeetingSeries.owner_user_id == current_user.id,
                         MeetingOccurrenceAttendee.user_id == current_user.id,
+                    ),
+                    or_(
+                        MeetingSeries.import_decision.is_(None),
+                        MeetingSeries.import_decision == ImportedSeriesDecision.kept,
                     ),
                     Task.is_done.is_(False),
                 )

--- a/src/agendable/web/templates/profile.html
+++ b/src/agendable/web/templates/profile.html
@@ -102,6 +102,33 @@
             {% endfor %}
         </ul>
     </section>
+
+    {% if google_calendar_sync_enabled %}
+    <section class="section-card">
+        <h3>Imported series review</h3>
+        {% if pending_import_series %}
+        <p><small>Review imported recurring meetings before adding them to your active series list.</small></p>
+        <ul class="list-clean">
+            {% for series in pending_import_series %}
+            <li>
+                <strong>{{ series.title }}</strong>
+                <small>— {{ pending_import_recurrence[series.id] }}</small>
+                <form method="post" action="/profile/calendar/google/import-series/{{ series.id }}/keep"
+                    class="inline-actions">
+                    <button type="submit">Keep</button>
+                </form>
+                <form method="post" action="/profile/calendar/google/import-series/{{ series.id }}/reject"
+                    class="inline-actions">
+                    <button type="submit">Delete</button>
+                </form>
+            </li>
+            {% endfor %}
+        </ul>
+        {% else %}
+        <p><em>No imported series waiting for review.</em></p>
+        {% endif %}
+    </section>
+    {% endif %}
 </section>
 
 <script>

--- a/tests/auth/test_google_calendar_sync_trigger.py
+++ b/tests/auth/test_google_calendar_sync_trigger.py
@@ -11,6 +11,9 @@ from agendable.db.models import (
     CalendarProvider,
     ExternalCalendarConnection,
     ExternalCalendarEventMirror,
+    ImportedSeriesDecision,
+    MeetingOccurrence,
+    MeetingSeries,
 )
 from agendable.services.external_calendar_api import ExternalCalendarAuth
 from agendable.services.google_calendar_sync_service import (
@@ -176,3 +179,163 @@ async def test_google_calendar_sync_route_syncs_primary_connection(
         )
     ).scalar_one()
     assert mirror.summary == "Manual Sync Meeting"
+
+
+@pytest.mark.asyncio
+async def test_keep_imported_series_marks_kept_and_maps_occurrence(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENDABLE_GOOGLE_CALENDAR_SYNC_ENABLED", "true")
+
+    await signup_and_login(
+        client,
+        first_name="Google",
+        last_name="KeepImported",
+        email="google-keep-imported@example.com",
+    )
+    user = await get_user_by_email(db_session, "google-keep-imported@example.com")
+
+    connection = ExternalCalendarConnection(
+        user_id=user.id,
+        provider=CalendarProvider.google,
+        external_calendar_id="primary",
+        access_token="google-access-token",
+        refresh_token="google-refresh-token",
+        is_enabled=True,
+    )
+    db_session.add(connection)
+    await db_session.flush()
+
+    series = MeetingSeries(
+        owner_user_id=user.id,
+        title="Imported Pending",
+        default_interval_days=7,
+        imported_from_provider=CalendarProvider.google,
+        import_external_series_id="master-keep-route",
+        import_decision=ImportedSeriesDecision.pending,
+    )
+    db_session.add(series)
+    await db_session.flush()
+
+    db_session.add(
+        ExternalCalendarEventMirror(
+            connection_id=connection.id,
+            linked_occurrence_id=None,
+            external_event_id="evt-keep-route",
+            external_recurring_event_id="master-keep-route",
+            external_status="confirmed",
+            summary="Imported Pending",
+            start_at=datetime(2026, 6, 10, 15, 0, tzinfo=UTC),
+            end_at=datetime(2026, 6, 10, 15, 30, tzinfo=UTC),
+            is_all_day=False,
+        )
+    )
+    await db_session.commit()
+
+    response = await client.post(
+        f"/profile/calendar/google/import-series/{series.id}/keep",
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    assert response.headers["location"] == "/profile"
+
+    await db_session.refresh(series)
+    assert series.import_decision == ImportedSeriesDecision.kept
+
+    occurrences = (
+        (
+            await db_session.execute(
+                select(MeetingOccurrence).where(MeetingOccurrence.series_id == series.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(occurrences) == 1
+
+
+@pytest.mark.asyncio
+async def test_reject_imported_series_marks_rejected_and_clears_occurrences(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENDABLE_GOOGLE_CALENDAR_SYNC_ENABLED", "true")
+
+    await signup_and_login(
+        client,
+        first_name="Google",
+        last_name="RejectImported",
+        email="google-reject-imported@example.com",
+    )
+    user = await get_user_by_email(db_session, "google-reject-imported@example.com")
+
+    connection = ExternalCalendarConnection(
+        user_id=user.id,
+        provider=CalendarProvider.google,
+        external_calendar_id="primary",
+        access_token="google-access-token",
+        refresh_token="google-refresh-token",
+        is_enabled=True,
+    )
+    db_session.add(connection)
+    await db_session.flush()
+
+    series = MeetingSeries(
+        owner_user_id=user.id,
+        title="Imported Reject",
+        default_interval_days=7,
+        imported_from_provider=CalendarProvider.google,
+        import_external_series_id="master-reject-route",
+        import_decision=ImportedSeriesDecision.pending,
+    )
+    db_session.add(series)
+    await db_session.flush()
+
+    occurrence = MeetingOccurrence(
+        series_id=series.id,
+        scheduled_at=datetime(2026, 6, 11, 15, 0, tzinfo=UTC),
+        notes="",
+    )
+    db_session.add(occurrence)
+    await db_session.flush()
+
+    mirror = ExternalCalendarEventMirror(
+        connection_id=connection.id,
+        linked_occurrence_id=occurrence.id,
+        external_event_id="evt-reject-route",
+        external_recurring_event_id="master-reject-route",
+        external_status="confirmed",
+        summary="Imported Reject",
+        start_at=occurrence.scheduled_at,
+        end_at=occurrence.scheduled_at,
+        is_all_day=False,
+    )
+    db_session.add(mirror)
+    await db_session.commit()
+
+    response = await client.post(
+        f"/profile/calendar/google/import-series/{series.id}/reject",
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    assert response.headers["location"] == "/profile"
+
+    await db_session.refresh(series)
+    assert series.import_decision == ImportedSeriesDecision.rejected
+
+    remaining_occurrences = (
+        (
+            await db_session.execute(
+                select(MeetingOccurrence).where(MeetingOccurrence.series_id == series.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert remaining_occurrences == []
+
+    await db_session.refresh(mirror)
+    assert mirror.linked_occurrence_id is None

--- a/tests/auth/test_google_calendar_sync_trigger.py
+++ b/tests/auth/test_google_calendar_sync_trigger.py
@@ -257,6 +257,44 @@ async def test_keep_imported_series_marks_kept_and_maps_occurrence(
 
 
 @pytest.mark.asyncio
+async def test_keep_imported_series_requires_connection_renders_profile_error(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENDABLE_GOOGLE_CALENDAR_SYNC_ENABLED", "true")
+
+    await signup_and_login(
+        client,
+        first_name="Google",
+        last_name="KeepNoConnection",
+        email="google-keep-no-connection@example.com",
+    )
+    user = await get_user_by_email(db_session, "google-keep-no-connection@example.com")
+
+    series = MeetingSeries(
+        owner_user_id=user.id,
+        title="Imported Pending",
+        default_interval_days=7,
+        imported_from_provider=CalendarProvider.google,
+        import_external_series_id="master-keep-no-connection",
+        import_decision=ImportedSeriesDecision.pending,
+    )
+    db_session.add(series)
+    await db_session.commit()
+
+    response = await client.post(
+        f"/profile/calendar/google/import-series/{series.id}/keep",
+        follow_redirects=False,
+    )
+    assert response.status_code == 400
+    assert "No Google Calendar connection found yet." in response.text
+
+    await db_session.refresh(series)
+    assert series.import_decision == ImportedSeriesDecision.pending
+
+
+@pytest.mark.asyncio
 async def test_reject_imported_series_marks_rejected_and_clears_occurrences(
     client: AsyncClient,
     db_session: AsyncSession,
@@ -339,3 +377,73 @@ async def test_reject_imported_series_marks_rejected_and_clears_occurrences(
 
     await db_session.refresh(mirror)
     assert mirror.linked_occurrence_id is None
+
+
+@pytest.mark.asyncio
+async def test_reject_imported_series_kept_state_returns_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENDABLE_GOOGLE_CALENDAR_SYNC_ENABLED", "true")
+
+    await signup_and_login(
+        client,
+        first_name="Google",
+        last_name="RejectKept",
+        email="google-reject-kept@example.com",
+    )
+    user = await get_user_by_email(db_session, "google-reject-kept@example.com")
+
+    series = MeetingSeries(
+        owner_user_id=user.id,
+        title="Imported Kept",
+        default_interval_days=7,
+        imported_from_provider=CalendarProvider.google,
+        import_external_series_id="master-reject-kept",
+        import_decision=ImportedSeriesDecision.kept,
+    )
+    db_session.add(series)
+    await db_session.commit()
+
+    response = await client.post(
+        f"/profile/calendar/google/import-series/{series.id}/reject",
+        follow_redirects=False,
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["keep", "reject"])
+async def test_import_review_routes_disabled_return_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    action: str,
+) -> None:
+    monkeypatch.setenv("AGENDABLE_GOOGLE_CALENDAR_SYNC_ENABLED", "false")
+
+    await signup_and_login(
+        client,
+        first_name="Google",
+        last_name="FeatureDisabled",
+        email=f"google-feature-disabled-{action}@example.com",
+    )
+    user = await get_user_by_email(db_session, f"google-feature-disabled-{action}@example.com")
+
+    series = MeetingSeries(
+        owner_user_id=user.id,
+        title="Imported Pending",
+        default_interval_days=7,
+        imported_from_provider=CalendarProvider.google,
+        import_external_series_id=f"master-feature-disabled-{action}",
+        import_decision=ImportedSeriesDecision.pending,
+    )
+    db_session.add(series)
+    await db_session.commit()
+
+    response = await client.post(
+        f"/profile/calendar/google/import-series/{series.id}/{action}",
+        follow_redirects=False,
+    )
+    assert response.status_code == 404

--- a/tests/test_calendar_event_mapping_service.py
+++ b/tests/test_calendar_event_mapping_service.py
@@ -11,6 +11,7 @@ from agendable.db.models import (
     CalendarProvider,
     ExternalCalendarConnection,
     ExternalCalendarEventMirror,
+    ImportedSeriesDecision,
     MeetingOccurrence,
     MeetingSeries,
     Task,
@@ -213,3 +214,146 @@ async def test_calendar_event_mapping_service_creates_next_occurrence_on_cancell
     assert refreshed_task is not None
     assert refreshed_task.occurrence_id == occ2.id
     assert refreshed_task.due_at == expected_occ2_at
+
+
+@pytest.mark.asyncio
+async def test_calendar_event_mapping_service_creates_pending_imported_series_without_occurrences(
+    db_session: AsyncSession,
+) -> None:
+    user = User(
+        email=f"sync-pending-{uuid.uuid4()}@example.com",
+        first_name="Sync",
+        last_name="Pending",
+        display_name="Sync Pending",
+        timezone="UTC",
+        password_hash=None,
+    )
+    db_session.add(user)
+    await db_session.flush()
+
+    connection = ExternalCalendarConnection(
+        user_id=user.id,
+        provider=CalendarProvider.google,
+        external_calendar_id="primary",
+        access_token="access-token",
+        refresh_token="refresh-token",
+    )
+    db_session.add(connection)
+    await db_session.flush()
+
+    mirror = ExternalCalendarEventMirror(
+        connection_id=connection.id,
+        external_event_id="evt-review-1",
+        external_recurring_event_id="master-review-1",
+        external_status="confirmed",
+        etag="etag-review-1",
+        summary="Birthday Calendar",
+        start_at=datetime(2026, 5, 2, 9, 0, tzinfo=UTC),
+        end_at=datetime(2026, 5, 2, 9, 30, tzinfo=UTC),
+        is_all_day=False,
+        external_updated_at=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+    )
+    db_session.add(mirror)
+    await db_session.flush()
+
+    mapped = await CalendarEventMappingService(session=db_session).map_mirrors(
+        connection=connection,
+        mirrors=[mirror],
+        recurring_event_details_by_id=None,
+    )
+    assert mapped == 0
+
+    series = (
+        (
+            await db_session.execute(
+                select(MeetingSeries).where(MeetingSeries.owner_user_id == user.id)
+            )
+        )
+        .scalars()
+        .one()
+    )
+    assert series.imported_from_provider == CalendarProvider.google
+    assert series.import_external_series_id == "master-review-1"
+    assert series.import_decision == ImportedSeriesDecision.pending
+
+    occurrences = (
+        (
+            await db_session.execute(
+                select(MeetingOccurrence).where(MeetingOccurrence.series_id == series.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert occurrences == []
+
+
+@pytest.mark.asyncio
+async def test_calendar_event_mapping_service_maps_after_imported_series_is_kept(
+    db_session: AsyncSession,
+) -> None:
+    user = User(
+        email=f"sync-keep-{uuid.uuid4()}@example.com",
+        first_name="Sync",
+        last_name="Keep",
+        display_name="Sync Keep",
+        timezone="UTC",
+        password_hash=None,
+    )
+    db_session.add(user)
+    await db_session.flush()
+
+    connection = ExternalCalendarConnection(
+        user_id=user.id,
+        provider=CalendarProvider.google,
+        external_calendar_id="primary",
+        access_token="access-token",
+        refresh_token="refresh-token",
+    )
+    db_session.add(connection)
+    await db_session.flush()
+
+    series = MeetingSeries(
+        owner_user_id=user.id,
+        title="Imported to Keep",
+        default_interval_days=7,
+        reminder_minutes_before=60,
+        imported_from_provider=CalendarProvider.google,
+        import_external_series_id="master-keep-1",
+        import_decision=ImportedSeriesDecision.kept,
+    )
+    db_session.add(series)
+    await db_session.flush()
+
+    mirror = ExternalCalendarEventMirror(
+        connection_id=connection.id,
+        external_event_id="evt-keep-1",
+        external_recurring_event_id="master-keep-1",
+        external_status="confirmed",
+        etag="etag-keep-1",
+        summary="Imported to Keep",
+        start_at=datetime(2026, 5, 6, 10, 0, tzinfo=UTC),
+        end_at=datetime(2026, 5, 6, 10, 30, tzinfo=UTC),
+        is_all_day=False,
+        external_updated_at=datetime(2026, 5, 5, 12, 0, tzinfo=UTC),
+    )
+    db_session.add(mirror)
+    await db_session.flush()
+
+    mapped = await CalendarEventMappingService(session=db_session).map_mirrors(
+        connection=connection,
+        mirrors=[mirror],
+        recurring_event_details_by_id=None,
+    )
+    assert mapped == 1
+
+    occurrences = (
+        (
+            await db_session.execute(
+                select(MeetingOccurrence).where(MeetingOccurrence.series_id == series.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(occurrences) == 1

--- a/tests/test_google_calendar_sync_service.py
+++ b/tests/test_google_calendar_sync_service.py
@@ -11,6 +11,7 @@ from agendable.db.models import (
     CalendarProvider,
     ExternalCalendarConnection,
     ExternalCalendarEventMirror,
+    ImportedSeriesDecision,
     MeetingOccurrence,
     MeetingSeries,
     User,
@@ -277,6 +278,16 @@ async def test_google_calendar_sync_service_maps_recurring_instances_with_rrule(
         refresh_token="refresh-token",
     )
     db_session.add(connection)
+    db_session.add(
+        MeetingSeries(
+            owner_user_id=user.id,
+            title="Team Sync",
+            default_interval_days=7,
+            imported_from_provider=CalendarProvider.google,
+            import_external_series_id="master-1",
+            import_decision=ImportedSeriesDecision.kept,
+        )
+    )
     await db_session.commit()
 
     evt1 = ExternalCalendarEvent(

--- a/tests/test_google_calendar_sync_service_backlinks.py
+++ b/tests/test_google_calendar_sync_service_backlinks.py
@@ -11,6 +11,7 @@ from agendable.db.models import (
     CalendarProvider,
     ExternalCalendarConnection,
     ExternalCalendarEventMirror,
+    ImportedSeriesDecision,
     MeetingSeries,
     User,
 )
@@ -129,6 +130,17 @@ async def test_sync_service_writes_back_occurrence_links_when_enabled(
         db_session,
         scope="https://www.googleapis.com/auth/calendar.events",
     )
+    db_session.add(
+        MeetingSeries(
+            owner_user_id=connection.user_id,
+            title="Team Sync",
+            default_interval_days=7,
+            imported_from_provider=CalendarProvider.google,
+            import_external_series_id="master-1",
+            import_decision=ImportedSeriesDecision.kept,
+        )
+    )
+    await db_session.commit()
 
     evt = ExternalCalendarEvent(
         event_id="evt-1",
@@ -183,6 +195,17 @@ async def test_sync_service_writes_back_series_links_when_enabled(
         db_session,
         scope="https://www.googleapis.com/auth/calendar.events",
     )
+    db_session.add(
+        MeetingSeries(
+            owner_user_id=connection.user_id,
+            title="Team Sync",
+            default_interval_days=7,
+            imported_from_provider=CalendarProvider.google,
+            import_external_series_id="master-1",
+            import_decision=ImportedSeriesDecision.kept,
+        )
+    )
+    await db_session.commit()
 
     evt = ExternalCalendarEvent(
         event_id="evt-1",

--- a/tests/web/test_dashboard.py
+++ b/tests/web/test_dashboard.py
@@ -12,6 +12,7 @@ from agendable.db.models import (
     CalendarProvider,
     ExternalCalendarConnection,
     ExternalCalendarEventMirror,
+    ImportedSeriesDecision,
     MeetingOccurrence,
     MeetingOccurrenceAttendee,
     MeetingSeries,
@@ -202,3 +203,42 @@ async def test_dashboard_labels_imported_upcoming_meetings(
     assert resp.status_code == 200
     assert str(occurrence.id) in resp.text
     assert "(Imported)" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_dashboard_hides_pending_imported_series(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    await login_user(
+        client,
+        "pending-owner@example.com",
+        "pw-pending",
+        first_name="Pending",
+        last_name="Owner",
+    )
+    owner = (
+        await db_session.execute(select(User).where(User.email == "pending-owner@example.com"))
+    ).scalar_one()
+
+    series = MeetingSeries(
+        owner_user_id=owner.id,
+        title=f"Pending Imported {uuid.uuid4()}",
+        default_interval_days=7,
+        imported_from_provider=CalendarProvider.google,
+        import_external_series_id=f"master-{uuid.uuid4()}",
+        import_decision=ImportedSeriesDecision.pending,
+    )
+    db_session.add(series)
+    await db_session.flush()
+
+    occurrence = MeetingOccurrence(
+        series_id=series.id,
+        scheduled_at=datetime.now(UTC) + timedelta(days=1),
+        notes="",
+    )
+    db_session.add(occurrence)
+    await db_session.commit()
+
+    resp = await client.get("/dashboard")
+    assert resp.status_code == 200
+    assert str(occurrence.id) not in resp.text


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs only
- [ ] CI / build / tooling
- [ ] Other (please describe):

## Testing
<!-- Check what you actually ran. -->
- [x] Unit tests
- [ ] Integration tests
- [x] Lint / formatting
- [x] Manual testing

## Data / config impact
- [x] Alembic migration included
- [ ] No migration needed (schema unchanged)
- [ ] New/changed env vars documented (README/PR notes)
- [x] No config/env var changes

## Checklist
- [x] I kept the change scoped and easy to review
- [x] I updated or added tests where it made sense
- [x] I updated docs / comments where needed
- [x] CI is green (or I explained why it isn’t)
- [x] No secrets or credentials were committed

## Summary
Adds the ability to select which synced calendar series the user actually wants to import.